### PR TITLE
更新NvEnc预设的名字

### DIFF
--- a/src/renderer/src/pages/Home/components/ffmpegSetting.vue
+++ b/src/renderer/src/pages/Home/components/ffmpegSetting.vue
@@ -223,15 +223,15 @@ const presetId = defineModel<string>({ required: true });
 const nvencPresets = [
   {
     value: "p1",
-    label: "lowest",
+    label: "fastest",
   },
   {
     value: "p2",
-    label: "lower",
+    label: "faster",
   },
   {
     value: "p3",
-    label: "low",
+    label: "fast",
   },
   {
     value: "p4",
@@ -239,15 +239,15 @@ const nvencPresets = [
   },
   {
     value: "p5",
-    label: "fast",
+    label: "slow",
   },
   {
     value: "p6",
-    label: "faster",
+    label: "slower",
   },
   {
     value: "p7",
-    label: "fastest",
+    label: "slowest",
   },
 ];
 const videoEncoders = ref([


### PR DESCRIPTION
根据`ffmpeg`关于`h264_nvenc`/`h265_nvenc`编码器的帮助文档显示，`p1`实际上是fastest(lowest quality)，`p7`为slowest(best quality)，原来的预设名称`p1`是lowest，`p7`是fastest
估计是写错了，中间`p2`/`p3`/`p5`/`p6`都同时改动了。