### PR TITLE
feat(regex): 增加正则表达式支持

### DIFF
--- a/packages/app/src/renderer/src/components/DanmuFactorySetting.vue
+++ b/packages/app/src/renderer/src/components/DanmuFactorySetting.vue
@@ -274,22 +274,35 @@
       <n-form-item style="width: 100%">
         <template #label>
           <Tip
-            text="屏蔽词"
+            text="屏蔽规则"
             tip="
-              目前支持三种屏蔽方式，分别是弹幕内容，uid，用户名，需以英文逗号分隔<br/>
-              弹幕内容：部分匹配，包含sc内容<br/>
-              uid：全匹配，格式为<10995238>，弹幕姬用户注意，即是你开启了记录raw，出于性能原因，此过滤也是无法使用的，请使用用户名替代<br/>
-              用户名：全匹配，格式为[暮色312]<br/>
-              此功能正在测试，如果出现开启后无法转换的情况请反馈"
+              目前支持四种屏蔽规则，分别是：<br/>
+              <ol>
+                <li>关键词屏蔽：弹幕（包括SC）内容中包含屏蔽词的，将会被屏蔽</li>
+                <li>UID屏蔽：弹幕由指定的UID发送的，将会被屏蔽。格式示例：<10995238></li>
+                <li>用户名屏蔽：弹幕由指定的用户名发送的，将会被屏蔽。格式示例：[暮色312]</li>
+                <li>正则表达式屏蔽：弹幕内容符合正则表达式的，将会被屏蔽</li>
+              </ol>
+
+              Ps: 弹幕姬用户注意：出于性能原因，即使已开启了记录raw，UID屏蔽也是<strong>无法使用</strong>的，请使用用户名屏蔽替代<br/>
+
+              <small>此功能正在测试，如果出现开启后无法转换的情况请反馈</small>"
           ></Tip>
         </template>
         <n-input
           v-model:value="config.blacklist"
           type="textarea"
-          placeholder="请输入需要屏蔽的关键词，以英文逗号分隔"
+          placeholder="请输入自定义屏蔽规则，使用英文逗号分隔"
           style="width: 100%"
           :input-props="{ spellcheck: 'false' }"
         />
+      </n-form-item>
+      <n-form-item label-placement="left">
+        <template #label> 正则表达式匹配 </template>
+        <n-switch v-model:value="config['blacklist-regex']"></n-switch>
+        <Tip
+          tip="开启后，<strong>所有屏蔽规则</strong>将被视为正则表达式，<strong>UID屏蔽和用户名屏蔽</strong>将会失效！"
+        ></Tip>
       </n-form-item>
     </div>
 

--- a/packages/shared/src/presets/danmuPreset.ts
+++ b/packages/shared/src/presets/danmuPreset.ts
@@ -44,6 +44,7 @@ export const DANMU_DEAFULT_CONFIG: DanmuConfig = {
   statmode: [],
   resolutionResponsive: false,
   blacklist: "",
+  "blacklist-regex": false,
   timeshift: 0,
   fontSizeResponsiveParams: [
     [1080, 40],

--- a/packages/types/src/preset.ts
+++ b/packages/types/src/preset.ts
@@ -34,6 +34,7 @@ export const danmuConfig = type({
   /** 字体大小自适应参数， */
   fontSizeResponsiveParams: fontSizeResponsiveParam.array(),
   blacklist: "string",
+  "blacklist-regex": "boolean",
   timeshift: "number",
 });
 export type DanmuConfig = typeof danmuConfig.infer;


### PR DESCRIPTION
Closes: #114 

## 总述

本次 PR 主要是对弹幕过滤功能的增强，添加了新的基于正则表达式的过滤选项，并更新了相关配置和 UI 元素。

完整更新描述如下：
- 更新了屏蔽规则的 'Tip' 提示，以描述新的基于正则表达式的过滤选项以及现有的过滤规则。
- 在“DanmuFactorySetting.vue”中添加了一个新的切换开关，以启用或禁用基于正则表达式的过滤，并附有解释其行为的工具提示。
- 在“danmuPreset.ts”中为默认弹幕配置添加了一个新的“blacklist-regex”属性，默认设置为“false”。
- 更新了 'preset.ts' 中的 'DanmuConfig' 类型，以包含新的 'blacklist-regex' 属性作为布尔值。

## 效果
<img width="1074" height="391" alt="image" src="https://github.com/user-attachments/assets/1fe28188-7c08-46d7-9a2c-7a9f80411ffc" />

## 另
由于项目庞大复杂，PR难免有未能顾及到之处，还请批评指正！