### PR TITLE
弹幕：增加描边模糊半径和描边不透明度设置

### DIFF
--- a/packages/app/src/renderer/src/components/DanmuFactorySetting.vue
+++ b/packages/app/src/renderer/src/components/DanmuFactorySetting.vue
@@ -31,9 +31,30 @@
             :max="4"
           />
         </n-form-item>
-        <n-form-item label="不透明度">
+
+        <n-form-item v-if="isAdvancedMode" label="描边模糊半径">
+          <n-input-number
+            v-model:value.number="config['outline-blur']"
+            class="input-number"
+            :min="0"
+          />
+        </n-form-item>
+
+        <n-form-item label="文字不透明度">
           <n-input-number
             v-model:value.number="config.opacity100"
+            class="input-number"
+            :min="0"
+            :max="100"
+            style="width: 130px"
+            :precision="2"
+          >
+            <template #suffix> % </template></n-input-number
+          >
+        </n-form-item>
+        <n-form-item label="描边不透明度">
+          <n-input-number
+            v-model:value.number="config['outline-opacity-percentage']"
             class="input-number"
             :min="0"
             :max="100"

--- a/packages/shared/src/danmu/danmakuFactory.ts
+++ b/packages/shared/src/danmu/danmakuFactory.ts
@@ -101,6 +101,9 @@ export class DanmakuFactory {
       } else if (key === "opacity100") {
         const value = ((config.opacity100 / 100) * 255).toFixed(0);
         return `--opacity ${value}`;
+      } else if (key === "outline-opacity-percentage") {
+        const value = ((config["outline-opacity-percentage"] / 100) * 255).toFixed(0);
+        return `--outline-opacity ${value}`;
       } else {
         return `--${key} ${value}`;
       }

--- a/packages/shared/src/presets/danmuPreset.ts
+++ b/packages/shared/src/presets/danmuPreset.ts
@@ -28,6 +28,8 @@ export const DANMU_DEAFULT_CONFIG: DanmuConfig = {
   fontsize: 40,
   opacity100: 100,
   outline: 1.0,
+  "outline-blur": 0,
+  "outline-opacity-percentage": 100,
   shadow: 0.0,
   displayarea: 1.0,
   scrollarea: 0.7,

--- a/packages/shared/test/danmu/danmakuFactory.test.ts
+++ b/packages/shared/test/danmu/danmakuFactory.test.ts
@@ -56,6 +56,8 @@ describe.concurrent("genDanmuArgs", () => {
       fontname: "Arial",
       blacklist: "",
       opacity100: 100,
+      "outline-blur": 1,
+      "outline-opacity-percentage": 60,
     };
 
     const expectedArgs = [
@@ -66,6 +68,8 @@ describe.concurrent("genDanmuArgs", () => {
       "--statmode TABLE-HISTOGRAM",
       '--fontname "Arial"',
       "--opacity 255",
+      "--outline-blur 1",
+      "--outline-opacity 153",
     ];
 
     // @ts-ignore

--- a/packages/types/src/preset.ts
+++ b/packages/types/src/preset.ts
@@ -13,6 +13,8 @@ export const danmuConfig = type({
   /** 百分制下的透明度 */
   opacity100: "number > 0",
   outline: "number",
+  "outline-blur": "number >= 0",
+  "outline-opacity-percentage": "0 <= number <= 100",
   shadow: "number",
   displayarea: "number",
   scrollarea: "number",


### PR DESCRIPTION
新增了**描边高斯模糊**和**描边不透明度**的配置选项，需要依赖于[上游 DanmakusFactory 新特性 #124](https://github.com/hihkm/DanmakuFactory/pull/124)