### PR TITLE
录制错误立即重试

### DIFF
--- a/packages/app/src/renderer/src/pages/setting/RecordSetting.vue
+++ b/packages/app/src/renderer/src/pages/setting/RecordSetting.vue
@@ -101,6 +101,16 @@
           </n-form-item>
           <n-form-item>
             <template #label>
+              <Tip
+                tip="当前录制错误后，会在下一个检查周期到来重新进行检查，可能导致缺少部分时间。<br/>
+                此开关使得在触发某些<b>已知错误</b>后会立即进行检查，每场直播最多进行五次重试。"
+                text="测试：录制错误立即重试"
+              ></Tip>
+            </template>
+            <n-switch v-model:value="config.recorder.recordRetryImmediately" />
+          </n-form-item>
+          <n-form-item>
+            <template #label>
               <Tip tip="用于提交反馈" text="调试模式"></Tip>
             </template>
             <n-switch v-model:value="config.recorder.debugMode" />

--- a/packages/liveManager/src/manager.ts
+++ b/packages/liveManager/src/manager.ts
@@ -61,6 +61,7 @@ const configurableProps = [
   "autoCheckInterval",
   "ffmpegOutputArgs",
   "biliBatchQuery",
+  "recordRetryImmediately",
 ] as const;
 type ConfigurableProp = (typeof configurableProps)[number];
 function isConfigurableProp(prop: unknown): prop is ConfigurableProp {
@@ -118,6 +119,8 @@ export interface RecorderManager<
   ffmpegOutputArgs: string;
   /** b站使用批量查询接口 */
   biliBatchQuery: boolean;
+  /** 测试：录制错误立即重试 */
+  recordRetryImmediately: boolean;
 }
 
 export type RecorderManagerCreateOpts<
@@ -218,6 +221,9 @@ export function createRecorderManager<
   // 用于是否触发LiveStart事件，不要重复触发
   const liveStartObj: Record<string, boolean> = {};
 
+  // 用于记录触发重试直播场次的次数
+  const retryCountObj: Record<string, number> = {};
+
   const manager: RecorderManager<ME, P, PE, E> = {
     // @ts-ignore
     ...mitt(),
@@ -253,9 +259,36 @@ export function createRecorderManager<
       recorder.on("videoFileCompleted", ({ filename }) =>
         this.emit("videoFileCompleted", { recorder, filename }),
       );
-      recorder.on("RecordStop", ({ recordHandle, reason }) =>
-        this.emit("RecordStop", { recorder, recordHandle, reason }),
-      );
+      recorder.on("RecordStop", ({ recordHandle, reason }) => {
+        this.emit("RecordStop", { recorder, recordHandle, reason });
+        // 如果reason中存在"invalid stream"，说明直播可能由于某些原因中断了，虽然会在下一次检查中继续，但是会遗漏一段时间。
+        // 这时候可以触发一次检查，但出于直播可能抽风的原因，为避免风控，一场直播最多触发五次。
+        // 测试阶段，还需要一个开关，默认关闭，几个版本后转正使用
+        if (
+          manager.recordRetryImmediately &&
+          reason &&
+          reason.includes("invalid stream") &&
+          recorder?.liveInfo?.liveId
+        ) {
+          const key = `${recorder.channelId}-${recorder.liveInfo?.liveId}`;
+
+          if (retryCountObj[key] > 5) return;
+          if (!retryCountObj[key]) {
+            retryCountObj[key] = 0;
+          }
+          if (retryCountObj[key] < 5) {
+            retryCountObj[key]++;
+          }
+          // 触发一次检查，等待一秒使状态清理完毕
+          setTimeout(() => {
+            recorder.checkLiveStatusAndRecord({
+              getSavePath(data) {
+                return genSavePathFromRule(manager, recorder, data);
+              },
+            });
+          }, 1000);
+        }
+      });
       recorder.on("Message", (message) => this.emit("Message", { recorder, message }));
       recorder.on("Updated", (keys) => this.emit("RecorderUpdated", { recorder, keys }));
       recorder.on("DebugLog", (log) => this.emit("RecorderDebugLog", { recorder, ...log }));
@@ -360,6 +393,7 @@ export function createRecorderManager<
 
     autoRemoveSystemReservedChars: opts.autoRemoveSystemReservedChars ?? true,
     biliBatchQuery: opts.biliBatchQuery ?? false,
+    recordRetryImmediately: opts.recordRetryImmediately ?? false,
 
     ffmpegOutputArgs:
       opts.ffmpegOutputArgs ??

--- a/packages/liveManager/src/manager.ts
+++ b/packages/liveManager/src/manager.ts
@@ -261,9 +261,10 @@ export function createRecorderManager<
       );
       recorder.on("RecordStop", ({ recordHandle, reason }) => {
         this.emit("RecordStop", { recorder, recordHandle, reason });
-        // 如果reason中存在"invalid stream"，说明直播可能由于某些原因中断了，虽然会在下一次检查中继续，但是会遗漏一段时间。
+        // 如果reason中存在"invalid stream"，说明直播由于某些原因中断了，虽然会在下一次周期检查中继续，但是会遗漏一段时间。
         // 这时候可以触发一次检查，但出于直播可能抽风的原因，为避免风控，一场直播最多触发五次。
         // 测试阶段，还需要一个开关，默认关闭，几个版本后转正使用
+        // 也许之后还能链接复用，但也会引入更多复杂度，需要谨慎考虑
         if (
           manager.recordRetryImmediately &&
           reason &&

--- a/packages/shared/src/enum.ts
+++ b/packages/shared/src/enum.ts
@@ -247,6 +247,7 @@ export const APP_DEFAULT_CONFIG: AppConfig = {
     qualityRetry: 0,
     videoFormat: "auto",
     useServerTimestamp: true,
+    recordRetryImmediately: false,
     bilibili: {
       uid: undefined,
       quality: 10000,

--- a/packages/shared/src/recorder/index.ts
+++ b/packages/shared/src/recorder/index.ts
@@ -85,6 +85,7 @@ export async function createRecorderManager(appConfig: AppConfig) {
     manager.autoCheckInterval = autoCheckInterval * 1000;
     manager.savePathRule = savePathRule;
     manager.biliBatchQuery = config?.recorder?.bilibili.useBatchQuery ?? false;
+    manager.recordRetryImmediately = config?.recorder?.recordRetryImmediately ?? false;
 
     if (autoCheckLiveStatusAndRecord) {
       if (autoCheckLiveStatusAndRecord && !manager.isCheckLoopRunning) {
@@ -123,6 +124,7 @@ export async function createRecorderManager(appConfig: AppConfig) {
     autoCheckInterval: autoCheckInterval * 1000,
     savePathRule: savePathRule,
     biliBatchQuery: config?.recorder?.bilibili.useBatchQuery ?? false,
+    recordRetryImmediately: config?.recorder?.recordRetryImmediately ?? false,
   });
 
   manager.on("RecorderDebugLog", ({ recorder, ...log }) => {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -338,6 +338,8 @@ export interface GlobalRecorder {
   checkInterval: number;
   /** 调试模式 */
   debugMode: boolean;
+  /** 测试：录制错误立即重试 */
+  recordRetryImmediately: boolean;
   /** 画质 */
   quality: "lowest" | "low" | "medium" | "high" | "highest";
   /** 线路 */


### PR DESCRIPTION
当前情况下，如果直播由于某些原因中断了，会在下一次周期检查中继续，但是会遗漏一段时间。

在已知错误的情况下，实际上可以对直播间立即进行重新检查，这样可以尽快进行录制，减少缺失的片段，此更新只聚焦于"invalid stream"错误，不针对其他错误，其他错误需要更多数据验证

也许未来之后还能链接复用，但也会引入更多复杂度，需要谨慎考虑。