### PR TITLE
录制：文件命名规则支持 `startTime` `recordStartTime` `liveStartTime` 参数

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - 录制：优化ffmpeg默认参数，fmp4使用m4s后缀 [#224](https://github.com/renmu123/biliLive-tools/pull/224)
 - 录制：回退“优化录制页面的请求元数据接口数量”需求
 - 录制：B站支持 `25000` 原画真彩画质
+- 录制：文件命名规则支持 `startTime` `recordStartTime` `liveStartTime` 参数
 - webhook：优化某些极端情况，尽量保证流程不被卡住
 - webhook：优化某些情况下的平台判断
 - 切片：优化ctrl+s的保存逻辑

--- a/docs/features/live-record.md
+++ b/docs/features/live-record.md
@@ -114,6 +114,9 @@ B站登录Cookie后可以解锁更高画质。
 - `{hour}` - 小时
 - `{min}` - 分钟
 - `{sec}` - 秒
+- `{startTime}` - 分段开始时间，Date对象
+- `{recordStartTime}` - 录制开始时间，Date对象
+- `{liveStartTime}` - 直播开始时间，Date对象，抖音同录制开始时间
 
 示例：`{platform}/{owner}/{year}-{month}-{date} {hour}-{min}-{sec} {title}`
 
@@ -124,6 +127,12 @@ B站登录Cookie后可以解锁更高画质。
 
 ```
 <% if (platform=='斗鱼') { %>C<% } %><% if (platform!='斗鱼') { %>D<% } %>:\录制\{platform}/{owner}/{year}-{month}-{date} {hour}-{min}-{sec} {title}
+```
+
+例如，将直播开始时间设置为文件夹
+
+```
+{platform}/{owner}/<%= recordStartTime.getFullYear() %>-<%= recordStartTime.getMonth()+1 %>-<%= recordStartTime.getDate() %>/{year}-{month}-{date} {hour}-{min}-{sec} {title}
 ```
 
 :::

--- a/packages/BilibiliRecorder/src/index.ts
+++ b/packages/BilibiliRecorder/src/index.ts
@@ -112,6 +112,7 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
       avatar: "",
       cover: "",
       liveId: liveId,
+      startTime: new Date(),
     };
     this.state = "idle";
   } catch (error) {
@@ -142,7 +143,7 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
   }
 
   const liveInfo = await getInfo(this.channelId);
-  const { owner, title, roomId } = liveInfo;
+  const { owner, title, roomId, startTime } = liveInfo;
   this.liveInfo = liveInfo;
 
   let res: Awaited<ReturnType<typeof getStream>>;
@@ -229,6 +230,7 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
     const reason = args[0] instanceof Error ? args[0].message : String(args[0]);
     this.recordHandle?.stop(reason);
   };
+  const recordStartTime = new Date();
 
   const recorder = createBaseRecorder(
     this.recorderType,
@@ -238,7 +240,13 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
       inputOptions: ffmpegInputOptions,
       segment: this.segment ?? 0,
       getSavePath: (opts) =>
-        getSavePath({ owner, title: opts.title ?? title, startTime: opts.startTime }),
+        getSavePath({
+          owner,
+          title: opts.title ?? title,
+          startTime: opts.startTime,
+          liveStartTime: startTime,
+          recordStartTime,
+        }),
       formatName: streamOptions.format_name as "flv" | "ts" | "fmp4",
       disableDanma: this.disableProvideCommentsWhenRecording,
       videoFormat: this.videoFormat,
@@ -257,6 +265,9 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
   const savePath = getSavePath({
     owner,
     title,
+    startTime: Date.now(),
+    liveStartTime: startTime,
+    recordStartTime,
   });
 
   try {

--- a/packages/DouYinRecorder/src/index.ts
+++ b/packages/DouYinRecorder/src/index.ts
@@ -215,7 +215,7 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
     this.state = "check-error";
     throw err;
   }
-  const { owner, title } = this.liveInfo;
+  const { owner, title, startTime } = this.liveInfo;
 
   this.state = "recording";
   const { currentStream: stream, sources: availableSources, streams: availableStreams } = res;
@@ -241,6 +241,7 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
     this.recordHandle?.stop(reason);
   };
 
+  const recordStartTime = new Date();
   const recorder = createBaseRecorder(
     this.recorderType,
     {
@@ -249,7 +250,13 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
       inputOptions: ffmpegInputOptions,
       segment: this.segment ?? 0,
       getSavePath: (opts) =>
-        getSavePath({ owner, title: opts.title ?? title, startTime: opts.startTime }),
+        getSavePath({
+          owner,
+          title: opts.title ?? title,
+          startTime: opts.startTime,
+          liveStartTime: startTime,
+          recordStartTime,
+        }),
       disableDanma: this.disableProvideCommentsWhenRecording,
       videoFormat: this.videoFormat ?? "auto",
       debugLevel: this.debugLevel ?? "none",
@@ -268,6 +275,9 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
   const savePath = getSavePath({
     owner,
     title,
+    startTime: Date.now(),
+    liveStartTime: startTime,
+    recordStartTime,
   });
 
   try {

--- a/packages/DouYuRecorder/src/index.ts
+++ b/packages/DouYuRecorder/src/index.ts
@@ -141,7 +141,7 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
     this.state = "check-error";
     throw error;
   }
-  const { living, owner, title } = this.liveInfo;
+  const { living, owner, title, startTime } = this.liveInfo;
 
   if (this.liveInfo.liveId === banLiveId) {
     this.tempStopIntervalCheck = true;
@@ -216,6 +216,7 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
   let isEnded = false;
   let isCutting = false;
 
+  const recordStartTime = new Date();
   const recorder = createBaseRecorder(
     this.recorderType,
     {
@@ -224,7 +225,13 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
       outputOptions: ffmpegOutputOptions,
       segment: this.segment ?? 0,
       getSavePath: (opts) =>
-        getSavePath({ owner, title: opts.title ?? title, startTime: opts.startTime }),
+        getSavePath({
+          owner,
+          title: opts.title ?? title,
+          startTime: opts.startTime,
+          liveStartTime: startTime,
+          recordStartTime,
+        }),
       disableDanma: this.disableProvideCommentsWhenRecording,
       videoFormat: this.videoFormat ?? "auto",
       debugLevel: this.debugLevel ?? "none",
@@ -240,6 +247,9 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
   const savePath = getSavePath({
     owner,
     title,
+    startTime: Date.now(),
+    liveStartTime: startTime,
+    recordStartTime,
   });
 
   try {

--- a/packages/HuYaRecorder/src/index.ts
+++ b/packages/HuYaRecorder/src/index.ts
@@ -143,7 +143,7 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
     this.state = "check-error";
     throw error;
   }
-  const { living, owner, title } = this.liveInfo;
+  const { living, owner, title, startTime } = this.liveInfo;
 
   if (this.liveInfo.liveId === banLiveId) {
     this.tempStopIntervalCheck = true;
@@ -219,6 +219,7 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
     this.recordHandle?.stop(reason);
   };
 
+  const recordStartTime = new Date();
   const recorder = createBaseRecorder(
     this.recorderType,
     {
@@ -227,7 +228,13 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
       inputOptions: ffmpegInputOptions,
       segment: this.segment ?? 0,
       getSavePath: (opts) =>
-        getSavePath({ owner, title: opts.title ?? title, startTime: opts.startTime }),
+        getSavePath({
+          owner,
+          title: opts.title ?? title,
+          startTime: opts.startTime,
+          liveStartTime: startTime,
+          recordStartTime,
+        }),
       disableDanma: this.disableProvideCommentsWhenRecording,
       videoFormat: this.videoFormat ?? "auto",
       debugLevel: this.debugLevel ?? "none",
@@ -242,6 +249,9 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
   const savePath = getSavePath({
     owner,
     title,
+    startTime: Date.now(),
+    liveStartTime: startTime,
+    recordStartTime,
   });
 
   try {

--- a/packages/app/src/renderer/components.d.ts
+++ b/packages/app/src/renderer/components.d.ts
@@ -58,6 +58,7 @@ declare module 'vue' {
     NSpace: typeof import('naive-ui')['NSpace']
     NSpin: typeof import('naive-ui')['NSpin']
     NSwitch: typeof import('naive-ui')['NSwitch']
+    NTable: typeof import('naive-ui')['NTable']
     NTabPane: typeof import('naive-ui')['NTabPane']
     NTabs: typeof import('naive-ui')['NTabs']
     NTag: typeof import('naive-ui')['NTag']

--- a/packages/app/src/renderer/src/pages/setting/RecordSetting.vue
+++ b/packages/app/src/renderer/src/pages/setting/RecordSetting.vue
@@ -448,7 +448,7 @@ const titleList = ref([
   },
 ]);
 const titleTip = computed(() => {
-  const base = `<b>谨慎修改，可能会导致无法录制</b><br/>支持ejs引擎<br/>`;
+  const base = `<b>谨慎修改，可能会导致无法录制</b><br/>支持ejs引擎，更多参数见文档<br/>`;
   return titleList.value
     .map((item) => {
       return `${item.label}：${item.value}<br/>`;

--- a/packages/liveManager/CHANGELOG.md
+++ b/packages/liveManager/CHANGELOG.md
@@ -4,6 +4,7 @@
 - mesio 引擎默认禁用任何代理
 - 优化弹幕内存占用
 - 录制：优化ffmpeg默认参数，fmp4使用m4s后缀 [#224](https://github.com/renmu123/biliLive-tools/pull/224)
+- savePathRule 参数支持 `startTime` `recordStartTime` `liveStartTime` 参数
 
 # 1.8.0
 

--- a/packages/liveManager/README.md
+++ b/packages/liveManager/README.md
@@ -94,19 +94,22 @@ setBililivePath("BililiveRecorder.Cli.exe");
 
 默认值为 `{platform}/{owner}/{year}-{month}-{date} {hour}-{min}-{sec} {title}`
 
-| 值          | 标签   |
-| ----------- | ------ |
-| {platform}  | 平台   |
-| {channelId} | 房间号 |
-| {remarks}   | 备注   |
-| {owner}     | 主播名 |
-| {title}     | 标题   |
-| {year}      | 年     |
-| {month}     | 月     |
-| {date}      | 日     |
-| {hour}      | 时     |
-| {min}       | 分     |
-| {sec}       | 秒     |
+| 值                | 标签                                       |
+| ----------------- | ------------------------------------------ |
+| {platform}        | 平台                                       |
+| {channelId}       | 房间号                                     |
+| {remarks}         | 备注                                       |
+| {owner}           | 主播名                                     |
+| {title}           | 标题                                       |
+| {year}            | 年                                         |
+| {month}           | 月                                         |
+| {date}            | 日                                         |
+| {hour}            | 时                                         |
+| {min}             | 分                                         |
+| {sec}             | 秒                                         |
+| {startTime}       | 分段开始时间，Date对象                     |
+| {recordStartTime} | 录制开始时间，Date对象                     |
+| {liveStartTime}   | 直播开始时间，Date对象，抖音同录制开始时间 |
 
 ## 事件
 

--- a/packages/liveManager/src/recorder.ts
+++ b/packages/liveManager/src/recorder.ts
@@ -131,7 +131,13 @@ export interface DebugLog {
   text: string;
 }
 
-export type GetSavePath = (data: { owner: string; title: string; startTime?: number }) => string;
+export type GetSavePath = (data: {
+  owner: string;
+  title: string;
+  startTime: number;
+  liveStartTime: Date;
+  recordStartTime: Date;
+}) => string;
 
 export interface Recorder<E extends AnyObject = UnknownObject>
   extends Emitter<{
@@ -167,7 +173,7 @@ export interface Recorder<E extends AnyObject = UnknownObject>
     living: boolean;
     owner: string;
     title: string;
-    startTime?: Date;
+    startTime: Date;
     avatar: string;
     cover: string;
     liveId?: string;

--- a/packages/liveManager/src/utils.ts
+++ b/packages/liveManager/src/utils.ts
@@ -151,8 +151,8 @@ export function formatDate(date: Date, format: string): string {
   return format.replace(/yyyy|MM|dd|HH|mm|ss/g, (matched) => map[matched]);
 }
 
-export function removeSystemReservedChars(filename: string) {
-  return filenamify(filename, { replacement: "_" });
+export function removeSystemReservedChars(str: string) {
+  return filenamify(str, { replacement: "_" });
 }
 
 export function isFfmpegStartSegment(line: string) {


### PR DESCRIPTION
close #234

## savePathRule 占位符参数

默认值为 `{platform}/{owner}/{year}-{month}-{date} {hour}-{min}-{sec} {title}`

| 值                | 标签                                       |
| ----------------- | ------------------------------------------ |
| {platform}        | 平台                                       |
| {channelId}       | 房间号                                     |
| {remarks}         | 备注                                       |
| {owner}           | 主播名                                     |
| {title}           | 标题                                       |
| {year}            | 年                                         |
| {month}           | 月                                         |
| {date}            | 日                                         |
| {hour}            | 时                                         |
| {min}             | 分                                         |
| {sec}             | 秒                                         |
| {startTime}       | 分段开始时间，Date对象                     |
| {recordStartTime} | 录制开始时间，Date对象                     |
| {liveStartTime}   | 直播开始时间，Date对象，抖音同录制开始时间 |

例如，将直播开始时间设置为文件夹

```
{platform}/{owner}/<%= recordStartTime.getFullYear() %>-<%= recordStartTime.getMonth()+1 %>-<%= recordStartTime.getDate() %>/{year}-{month}-{date} {hour}-{min}-{sec} {title}