### PR TITLE
B站上传：续传水印

### DIFF
--- a/packages/shared/src/task/bili.ts
+++ b/packages/shared/src/task/bili.ts
@@ -336,6 +336,15 @@ export function formatOptions(options: BiliupConfig, coverDir: string | undefine
   return data;
 }
 
+export function formatEditOption(options: BiliupConfig): Partial<MediaOptions> {
+  return {
+    watermark:
+      options.copyright === 2 || options.watermark === undefined
+        ? undefined
+        : { state: options.watermark },
+  };
+}
+
 /**
  * 合集列表
  */
@@ -373,11 +382,10 @@ export async function editMediaApi(
   video: { cid: number; filename: string; title: string; desc?: string }[],
   options: BiliupConfig,
 ) {
-  const mediaOptions = {};
   console.log("编辑视频", options);
 
   // const globalConfig = container.resolve("globalConfig");
-  // const mediaOptions = formatOptions(options, path.join(globalConfig.userDataPath, "cover"));
+  const mediaOptions = formatEditOption(options);
   const client = createClient(uid);
   return client.platform.editMediaWebApi(video, { aid, ...mediaOptions }, "append");
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -984,6 +984,8 @@ export interface BiliupConfig {
   dtime?: number;
 }
 
+export type BiliupContinueConfig = Partial<BiliupConfig>;
+
 export type BiliupConfigAppend = Partial<BiliupConfig> & {
   vid: string | number;
 };


### PR DESCRIPTION
续传的时候需要提交水印设置，否则无水印设置会被覆盖
- 稿件一旦创建，前端是不可修改水印设置，但通过接口可修改