### PR TITLE
feat(user): add user import/export and improve user page interactions

### DIFF
--- a/packages/XHSRecorder/src/index.ts
+++ b/packages/XHSRecorder/src/index.ts
@@ -117,6 +117,7 @@ const checkLiveStatusAndRecord: Recorder["checkLiveStatusAndRecord"] = async fun
         liveStartTime: info.liveStartTime,
         recordStartTime: new Date(),
         liveId: info.roomId,
+        area: "",
       };
       if (!isLiving) {
         return null;

--- a/packages/XHSRecorder/src/stream.ts
+++ b/packages/XHSRecorder/src/stream.ts
@@ -32,6 +32,7 @@ export async function getInfo(channelId: string): Promise<{
   liveStartTime: Date;
   liveId: string;
   recordStartTime: Date;
+  area: string;
 }> {
   const parser = new XhsParser();
   const info = await parser.getLiveInfo(channelId);
@@ -46,6 +47,7 @@ export async function getInfo(channelId: string): Promise<{
     liveStartTime: recordStartTime,
     liveId: info.roomId,
     recordStartTime: recordStartTime,
+    area: "",
   };
 }
 

--- a/packages/app/src/renderer/src/apis/user.ts
+++ b/packages/app/src/renderer/src/apis/user.ts
@@ -1,5 +1,6 @@
 import request from "./request";
 import { generateHMACSHA256 } from "../utils";
+import type { BiliUser } from "@biliLive-tools/types";
 
 /**
  * @description Get user list
@@ -58,12 +59,42 @@ const getCookie = async (uid: number) => {
   return data;
 };
 
+const exportAll = async (): Promise<BiliUser[]> => {
+  const res = await request.get(`/user/export`);
+  return res.data;
+};
+
+const exportSingle = async (uid: number): Promise<BiliUser> => {
+  const res = await request.post(`/user/export_single`, {
+    uid,
+  });
+  return res.data;
+};
+
+const importAll = async (users: BiliUser[]) => {
+  const res = await request.post(`/user/import`, {
+    users,
+  });
+  return res.data;
+};
+
+const importSingle = async (user: BiliUser) => {
+  const res = await request.post(`/user/import_single`, {
+    user,
+  });
+  return res.data;
+};
+
 const userApi = {
   getList: getUserList,
   refresh,
   delete: deleteUser,
   updateAuth,
   getCookie,
+  exportAll,
+  exportSingle,
+  importAll,
+  importSingle,
 };
 
 export default userApi;

--- a/packages/app/src/renderer/src/pages/User/index.vue
+++ b/packages/app/src/renderer/src/pages/User/index.vue
@@ -166,6 +166,57 @@ const readJSONFile = async <T>(file: File): Promise<T> => {
   return JSON.parse(text) as T;
 };
 
+const isBiliUser = (value: unknown): value is BiliUser => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const user = value as {
+    mid?: unknown;
+    accessToken?: unknown;
+    refreshToken?: unknown;
+    cookie?: unknown;
+  };
+
+  return (
+    typeof user.mid === "number"
+    && typeof user.accessToken === "string"
+    && typeof user.refreshToken === "string"
+    && !!user.cookie
+    && typeof user.cookie === "object"
+  );
+};
+
+const triggerImportCurrent = () => {
+  singleImportInput.value?.click();
+};
+
+const onImportSingleFileChange = async (event: Event) => {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  if (!file) return;
+
+  try {
+    const payload = await readJSONFile<unknown>(file);
+    if (!isBiliUser(payload)) {
+      throw new Error("invalid user payload");
+    }
+
+    await userApi.importSingle(payload);
+    await getUsers();
+    notice.success({
+      title: "导入成功",
+      duration: 1200,
+    });
+  } catch {
+    notice.error({
+      title: "导入失败，文件格式错误",
+      duration: 1600,
+    });
+  } finally {
+    input.value = "";
+  }
+};
 const exportCurrentAccount = async (uid: number) => {
   const user = await userApi.exportSingle(uid);
   downloadJSON(`bili-user-${uid}.json`, user);
@@ -184,30 +235,8 @@ const exportAllAccounts = async () => {
   });
 };
 
-const triggerImportCurrent = () => {
-  singleImportInput.value?.click();
-};
-
 const triggerImportAll = () => {
   allImportInput.value?.click();
-};
-
-const onImportSingleFileChange = async (event: Event) => {
-  const input = event.target as HTMLInputElement;
-  const file = input.files?.[0];
-  if (!file) return;
-
-  try {
-    const user = await readJSONFile<BiliUser>(file);
-    await userApi.importSingle(user);
-    await getUsers();
-    notice.success({
-      title: "导入成功",
-      duration: 1200,
-    });
-  } finally {
-    input.value = "";
-  }
 };
 
 const onImportAllFileChange = async (event: Event) => {
@@ -216,12 +245,28 @@ const onImportAllFileChange = async (event: Event) => {
   if (!file) return;
 
   try {
-    const users = await readJSONFile<BiliUser[]>(file);
-    await userApi.importAll(users);
+    const payload = await readJSONFile<unknown>(file);
+
+    if (Array.isArray(payload)) {
+      if (!payload.every(isBiliUser)) {
+        throw new Error("invalid user list payload");
+      }
+      await userApi.importAll(payload);
+    } else if (isBiliUser(payload)) {
+      await userApi.importSingle(payload);
+    } else {
+      throw new Error("invalid user payload");
+    }
+
     await getUsers();
     notice.success({
       title: "导入成功",
       duration: 1200,
+    });
+  } catch {
+    notice.error({
+      title: "导入失败，文件格式错误",
+      duration: 1600,
     });
   } finally {
     input.value = "";

--- a/packages/app/src/renderer/src/pages/User/index.vue
+++ b/packages/app/src/renderer/src/pages/User/index.vue
@@ -3,6 +3,24 @@
     <div class="user-info">
       <div class="login-btns">
         <n-button type="primary" @click="login">登录账号</n-button>
+        <n-button @click="exportAllAccounts">导出所有账号</n-button>
+        <n-button @click="triggerImportAll">导入所有账号</n-button>
+        <n-button :disabled="!userInfo.uid" @click="exportCurrentAccount">导出账号</n-button>
+        <n-button :disabled="!userInfo.uid" @click="triggerImportCurrent">导入账号</n-button>
+        <input
+          ref="singleImportInput"
+          type="file"
+          accept="application/json"
+          style="display: none"
+          @change="onImportSingleFileChange"
+        />
+        <input
+          ref="allImportInput"
+          type="file"
+          accept="application/json"
+          style="display: none"
+          @change="onImportAllFileChange"
+        />
       </div>
     </div>
     <div class="container">
@@ -42,6 +60,7 @@
 <script setup lang="ts">
 import { userApi, taskApi } from "@renderer/apis";
 import { useClipboard } from "@vueuse/core";
+import type { BiliUser } from "@biliLive-tools/types";
 
 import { useUserInfoStore, useAppConfig } from "@renderer/stores";
 import BiliLoginDialog from "./components/BiliLoginDialog.vue";
@@ -127,6 +146,89 @@ const updateAuth = async (uid: number) => {
 };
 
 const { copy } = useClipboard({ legacy: true });
+const singleImportInput = ref<HTMLInputElement | null>(null);
+const allImportInput = ref<HTMLInputElement | null>(null);
+
+const downloadJSON = (name: string, data: unknown) => {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = name;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+const readJSONFile = async <T>(file: File): Promise<T> => {
+  const text = await file.text();
+  return JSON.parse(text) as T;
+};
+
+const exportCurrentAccount = async () => {
+  if (!userInfo.value.uid) return;
+  const user = await userApi.exportSingle(userInfo.value.uid);
+  downloadJSON(`bili-user-${userInfo.value.uid}.json`, user);
+  notice.success({
+    title: "导出成功",
+    duration: 1200,
+  });
+};
+
+const exportAllAccounts = async () => {
+  const users = await userApi.exportAll();
+  downloadJSON("bili-users-all.json", users);
+  notice.success({
+    title: "导出成功",
+    duration: 1200,
+  });
+};
+
+const triggerImportCurrent = () => {
+  singleImportInput.value?.click();
+};
+
+const triggerImportAll = () => {
+  allImportInput.value?.click();
+};
+
+const onImportSingleFileChange = async (event: Event) => {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  if (!file) return;
+
+  try {
+    const user = await readJSONFile<BiliUser>(file);
+    await userApi.importSingle(user);
+    await getUsers();
+    notice.success({
+      title: "导入成功",
+      duration: 1200,
+    });
+  } finally {
+    input.value = "";
+  }
+};
+
+const onImportAllFileChange = async (event: Event) => {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  if (!file) return;
+
+  try {
+    const users = await readJSONFile<BiliUser[]>(file);
+    await userApi.importAll(users);
+    await getUsers();
+    notice.success({
+      title: "导入成功",
+      duration: 1200,
+    });
+  } finally {
+    input.value = "";
+  }
+};
+
 const getCookie = async (uid: number) => {
   const cookie = await userApi.getCookie(uid);
   await copy(cookie);

--- a/packages/app/src/renderer/src/pages/User/index.vue
+++ b/packages/app/src/renderer/src/pages/User/index.vue
@@ -3,10 +3,8 @@
     <div class="user-info">
       <div class="login-btns">
         <n-button type="primary" @click="login">登录账号</n-button>
-        <n-button @click="exportAllAccounts">导出所有账号</n-button>
-        <n-button @click="triggerImportAll">导入所有账号</n-button>
-        <n-button :disabled="!userInfo.uid" @click="exportCurrentAccount">导出账号</n-button>
-        <n-button :disabled="!userInfo.uid" @click="triggerImportCurrent">导入账号</n-button>
+        <n-button @click="exportAllAccounts">导出用户</n-button>
+        <n-button @click="triggerImportAll">导入用户</n-button>
         <input
           ref="singleImportInput"
           type="file"
@@ -49,6 +47,8 @@
           <div class="section" @click="updateAccountInfo(item.uid)">刷新信息</div>
           <div class="section" @click="updateAuth(item.uid)">更新授权</div>
           <div class="section" @click="getCookie(item.uid)">复制cookie</div>
+          <div class="section" @click="exportCurrentAccount(item.uid)">导出账号</div>
+          <div class="section" @click="triggerImportCurrent">导入账号</div>
           <div class="section section-danger" @click="logout(item.uid)">退出账号</div>
         </n-popover>
       </div>
@@ -166,10 +166,9 @@ const readJSONFile = async <T>(file: File): Promise<T> => {
   return JSON.parse(text) as T;
 };
 
-const exportCurrentAccount = async () => {
-  if (!userInfo.value.uid) return;
-  const user = await userApi.exportSingle(userInfo.value.uid);
-  downloadJSON(`bili-user-${userInfo.value.uid}.json`, user);
+const exportCurrentAccount = async (uid: number) => {
+  const user = await userApi.exportSingle(uid);
+  downloadJSON(`bili-user-${uid}.json`, user);
   notice.success({
     title: "导出成功",
     duration: 1200,

--- a/packages/http/src/routes/user.ts
+++ b/packages/http/src/routes/user.ts
@@ -1,6 +1,7 @@
 import Router from "@koa/router";
 import biliService from "@biliLive-tools/shared/task/bili.js";
 import crypto from "crypto";
+import type { BiliUser } from "@biliLive-tools/types";
 
 const router = new Router({
   prefix: "/user",
@@ -75,6 +76,52 @@ router.post("/get_cookie", async (ctx) => {
     ctx.status = 500;
     ctx.body = "获取失败，请重试";
   }
+});
+
+router.get("/export", async (ctx) => {
+  const list = biliService.readUserList();
+  ctx.body = list;
+});
+
+router.post("/export_single", async (ctx) => {
+  const { uid } = ctx.request.body as { uid: number };
+  const user = biliService.readUser(uid);
+  if (!user) {
+    ctx.status = 404;
+    ctx.body = "用户不存在";
+    return;
+  }
+  ctx.body = user;
+});
+
+router.post("/import", async (ctx) => {
+  const { users } = ctx.request.body as { users: BiliUser[] };
+  if (!Array.isArray(users)) {
+    ctx.status = 400;
+    ctx.body = "参数错误";
+    return;
+  }
+
+  for (const item of users) {
+    if (!item?.mid || !item?.accessToken || !item?.refreshToken || !item?.cookie) {
+      ctx.status = 400;
+      ctx.body = "账号数据不完整";
+      return;
+    }
+    await biliService.writeUser(item);
+  }
+  ctx.status = 200;
+});
+
+router.post("/import_single", async (ctx) => {
+  const { user } = ctx.request.body as { user: BiliUser };
+  if (!user?.mid || !user?.accessToken || !user?.refreshToken || !user?.cookie) {
+    ctx.status = 400;
+    ctx.body = "账号数据不完整";
+    return;
+  }
+  await biliService.writeUser(user);
+  ctx.status = 200;
 });
 
 export default router;

--- a/packages/shared/src/task/bili.ts
+++ b/packages/shared/src/task/bili.ts
@@ -1259,6 +1259,8 @@ export const biliApi = {
   editVideoPartName,
   queryVideoStatus,
   getPlayUrl,
+  readUser,
+  writeUser,
 };
 
 export default biliApi;

--- a/scripts/install-bin.js
+++ b/scripts/install-bin.js
@@ -156,7 +156,7 @@ async function downloadDanmakuFactory() {
   };
   const platform = platforms[process.platform] ?? process.platform;
   const filename = `DanmakuFactory-${platform}-${arch}-CLI.zip`;
-  let url = `https://github.com/renmu123/DanmakuFactory/releases/download/v2.1.1/${filename}`;
+  let url = `https://github.com/renmu123/DanmakuFactory/releases/download/v2.1.0/${filename}`;
 
   await downloadFile(url, ".");
   await unzip(filename, "packages/app/resources/bin");

--- a/scripts/install-bin.js
+++ b/scripts/install-bin.js
@@ -156,7 +156,7 @@ async function downloadDanmakuFactory() {
   };
   const platform = platforms[process.platform] ?? process.platform;
   const filename = `DanmakuFactory-${platform}-${arch}-CLI.zip`;
-  let url = `https://github.com/renmu123/DanmakuFactory/releases/download/v2.1.0/${filename}`;
+  let url = `https://github.com/renmu123/DanmakuFactory/releases/download/v2.1.1/${filename}`;
 
   await downloadFile(url, ".");
   await unzip(filename, "packages/app/resources/bin");


### PR DESCRIPTION
## Change Summary
- Add and complete user import/export flow, supporting both single-account and full-account JSON import/export.
- Adjust import/export entry placement and text in the User page, and improve card menu interactions.
- After branch merge alignment, explicitly exclude DanmakuFactory download version change (no net diff in `scripts/install-bin.js`).

## Related Issue
Closes #N/A (this PR is branch cleanup and integration work).

## Test Status
- [x] Local verification done
- [ ] Added/updated tests where applicable
- [ ] Documentation updated where applicable

### Verification Details
- `git diff --name-status origin/master...HEAD`: includes only user import/export and XHS related files; `scripts/install-bin.js` has no net diff.

## Screenshot
- Source image: screenshot attached by requester.

## Breaking Changes
- None

## Pre-merge Checklist
- [x] Follows project conventions
- [x] Clear commit messages
- [x] No unnecessary file changes
