### PR TITLE
【录制】linux下默认的mesio使用musl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## Bug修复
 
 - 虚拟录制：修复某些情况下birthtime为空时使用备用方案 [#390](https://github.com/renmu123/biliLive-tools/issues/390)
+- 录制：linux下默认的mesio使用musl
 
 # 3.13.1(2026.04.30)
 

--- a/scripts/install-bin.js
+++ b/scripts/install-bin.js
@@ -58,8 +58,8 @@ async function downloadMesio() {
     "win32-x64": "mesio-x86_64-pc-windows-msvc.exe",
     "darwin-arm64": "mesio-aarch64-apple-darwin",
     "darwin-x64": "mesio-x86_64-apple-darwin",
-    "linux-arm64": "mesio-aarch64-unknown-linux-gnu",
-    "linux-x64": "mesio-x86_64-unknown-linux-gnu",
+    "linux-arm64": "mesio-aarch64-unknown-linux-musl",
+    "linux-x64": "mesio-x86_64-unknown-linux-musl",
   };
   const target = `${process.platform}-${process.arch}`;
   const assetName = mesioAssets[target];


### PR DESCRIPTION
修复`/lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.39' not found (required by /app/bin/mesio)`