### PR TITLE
mesio二进制依赖升级到 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@
 ## Bug修复
 
 - 虚拟录制：修复某些情况下birthtime为空时使用备用方案 [#390](https://github.com/renmu123/biliLive-tools/issues/390)
-- 录制：linux下默认的mesio使用musl
+- 录制：linux下默认的mesio使用musl [#439](https://github.com/renmu123/biliLive-tools/pull/439)
+
+## 其他
+
+- mesio二进制依赖升级到 0.4.1
 
 # 3.13.1(2026.04.30)
 

--- a/docs/development/guide.md
+++ b/docs/development/guide.md
@@ -71,7 +71,7 @@ pnpm run install:bin
 - **FFmpeg**：[n7.1](https://github.com/yt-dlp/FFmpeg-Builds)
 - **FFprobe**：[n7.1](https://github.com/yt-dlp/FFmpeg-Builds)
 - **录播姬cli**：[3.3.3](https://github.com/renmu123/BililiveRecorder)
-- **mesio**：[0.4.0](https://github.com/hua0512/rust-srec/releases/tag/mesio-v0.4.0)
+- **mesio**：[0.4.1](https://github.com/hua0512/rust-srec/releases/tag/mesio-v0.4.1)
 - **audiowaveform**：[1.10.2](https://github.com/bbc/audiowaveform)
 
 同时需要在应用设置中配置可执行文件路径。

--- a/packages/liveManager/CHANGELOG.md
+++ b/packages/liveManager/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.16.2
+
+- mesio二进制依赖升级到 0.4.1
+
 # 1.16.1
 
 - 弹幕统计重构 [#415](https://github.com/renmu123/biliLive-tools/pull/415)

--- a/packages/liveManager/src/downloader/mesioDownloader.ts
+++ b/packages/liveManager/src/downloader/mesioDownloader.ts
@@ -181,7 +181,7 @@ export class mesioDownloader extends EventEmitter implements IDownloader {
   }
 
   createCommand() {
-    const inputOptions = [...this.inputOptions, "--fix", "--no-proxy"];
+    const inputOptions = [...this.inputOptions, "--fix", "--no-proxy", "--disable-log-file"];
     if (this.debugLevel === "verbose") {
       inputOptions.push("-v");
     }

--- a/scripts/install-bin.js
+++ b/scripts/install-bin.js
@@ -53,7 +53,7 @@ async function downloadFile(url, desc, options = {}) {
  */
 async function downloadMesio() {
   // https://github.com/hua0512/rust-srec
-  const version = "mesio-v0.4.0";
+  const version = "mesio-v0.4.1";
   const mesioAssets = {
     "win32-x64": "mesio-x86_64-pc-windows-msvc.exe",
     "darwin-arm64": "mesio-aarch64-apple-darwin",


### PR DESCRIPTION
升级版本至[0.4.1](https://github.com/hua0512/rust-srec/releases/tag/mesio-v0.4.1)，额外添加了`--disable-log-file`参数，可能会导致不兼容