### PR TITLE
上传崩溃报告 选项支持

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 功能
 
 - 支持外部webhook事件订阅 [#458](https://github.com/renmu123/biliLive-tools/pull/458)
+- 支持新参数`上传崩溃报告`，用于将崩溃报告上传至Sentry服务器，默认关闭
 
 ## 优化
 

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -38,6 +38,24 @@ import type { Theme, GlobalConfig } from "@biliLive-tools/types";
 export let mainWin: BrowserWindow;
 export let container = createContainer();
 
+const SENTRY_CRASH_DSN =
+  "https://aa05399bf7cf8b619177be3284d28fc8@o4511547045576704.ingest.us.sentry.io/4511547052720128";
+
+const getSentryMinidumpSubmitURL = (dsn: string) => {
+  try {
+    const url = new URL(dsn);
+    const projectId = url.pathname.replace(/^\/+/, "");
+    if (!projectId || !url.username) {
+      throw new Error("Missing Sentry project id or public key.");
+    }
+
+    return `${url.protocol}//${url.host}/api/${projectId}/minidump/?sentry_key=${url.username}`;
+  } catch (error) {
+    log.warn("Failed to parse Sentry crash DSN.", error);
+    return undefined;
+  }
+};
+
 contextMenu({
   showSelectAll: false,
   showSearchWithGoogle: false,
@@ -552,8 +570,15 @@ const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
   app.quit();
 } else {
+  const sentryCrashSubmitURL = getSentryMinidumpSubmitURL(SENTRY_CRASH_DSN);
   crashReporter.start({
     uploadToServer: false,
+    submitURL: sentryCrashSubmitURL,
+    compress: true,
+    rateLimit: true,
+    globalExtra: {
+      product: "biliLive-tools",
+    },
   });
   app.whenReady().then(() => {
     electronApp.setAppUserModelId("com.electron");
@@ -733,6 +758,9 @@ const appInit = async () => {
     } catch (error) {
       log.error("自动更新检查失败:", error);
     }
+  }
+  if (appConfig.get("uploadCrashReport")) {
+    crashReporter.setUploadToServer(true);
   }
   // taskQueueListen(container);
 };

--- a/packages/app/src/renderer/src/pages/setting/index.vue
+++ b/packages/app/src/renderer/src/pages/setting/index.vue
@@ -19,6 +19,12 @@
           <n-form ref="formRef" label-placement="left" :label-width="160">
             <n-form-item>
               <template #label>
+                <Tip text="上传崩溃报告" tip="上传崩溃报告至Sentry服务器"></Tip>
+              </template>
+              <n-switch v-model:value="config.uploadCrashReport" />
+            </n-form-item>
+            <n-form-item>
+              <template #label>
                 <Tip
                   text="删除至回收站"
                   tip="关闭后若使用“删除源文件”等选项，文件将被直接删除，不会进入回收站，如果使用的文件为smb等远程协议挂载，可能会删除失败"

--- a/packages/shared/src/enum.ts
+++ b/packages/shared/src/enum.ts
@@ -32,6 +32,7 @@ export enum LLMType {
 
 export const APP_DEFAULT_CONFIG: AppConfig = {
   logLevel: "debug",
+  uploadCrashReport: false,
   autoUpdate: true,
   autoLaunch: false,
   trash: false,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -607,6 +607,8 @@ export interface AppConfig {
   audiowaveformPath: string;
   /** 缓存文件夹 */
   cacheFolder: string;
+  /** 上传崩溃报告 */
+  uploadCrashReport: boolean;
   /** 保存到回收站 */
   trash: boolean;
   /** 自动检查更新 */


### PR DESCRIPTION
支持新参数`上传崩溃报告`，用于将崩溃报告上传至Sentry服务器，默认关闭