### PR TITLE
[codex] Support multiple notification channels

### DIFF
--- a/packages/app/src/renderer/src/apis/config.ts
+++ b/packages/app/src/renderer/src/apis/config.ts
@@ -2,6 +2,8 @@ import type { AppConfig } from "@biliLive-tools/types";
 
 import request from "./request";
 
+type NotifyType = AppConfig["notification"]["setting"]["type"];
+
 export interface VerifyBiliKeyResponse {
   configured: boolean;
   valid: boolean;
@@ -33,7 +35,9 @@ export const set = async <K extends keyof AppConfig>(
   }
 };
 
-export const save = async <K extends keyof AppConfig>(data: AppConfig[K]): Promise<void> => {
+export const save = async <K extends keyof AppConfig>(
+  data: AppConfig[K],
+): Promise<void> => {
   if (window.isWeb) {
     const res = await request.post(`/config`, data);
     return res.data;
@@ -42,7 +46,9 @@ export const save = async <K extends keyof AppConfig>(data: AppConfig[K]): Promi
   }
 };
 
-export const resetBin = async (type: "ffmpeg" | "ffprobe" | "danmakuFactory"): Promise<string> => {
+export const resetBin = async (
+  type: "ffmpeg" | "ffprobe" | "danmakuFactory",
+): Promise<string> => {
   const res = await request.post(`/config/resetBin`, { type });
   return res.data;
 };
@@ -51,9 +57,14 @@ export const notifyTest = async (
   title: string,
   desp: string,
   options: AppConfig,
-  notifyType: AppConfig["notification"]["setting"]["type"],
+  notifyType: NotifyType | NonNullable<NotifyType>[],
 ): Promise<void> => {
-  const res = await request.post(`/config/notifyTest`, { title, desp, options, notifyType });
+  const res = await request.post(`/config/notifyTest`, {
+    title,
+    desp,
+    options,
+    notifyType,
+  });
   return res.data;
 };
 
@@ -75,7 +86,9 @@ export const importConfig = async (file: File): Promise<void> => {
   return res.data;
 };
 
-export const verifyBiliKey = async (key: string): Promise<VerifyBiliKeyResponse> => {
+export const verifyBiliKey = async (
+  key: string,
+): Promise<VerifyBiliKeyResponse> => {
   const res = await request.post(`/config/verifyBiliKey`, { key });
   return res.data;
 };

--- a/packages/app/src/renderer/src/pages/setting/NotificationSetting.vue
+++ b/packages/app/src/renderer/src/pages/setting/NotificationSetting.vue
@@ -2,13 +2,14 @@
   <n-form label-placement="left" :label-width="120">
     <n-form-item label="通知类型">
       <n-select
-        v-model:value="config.notification.setting.type"
+        v-model:value="notificationTypes"
         :options="typeOptions"
+        multiple
         placeholder="请选择通知类型"
         clearable
       />
       <n-button
-        v-if="config.notification.setting.type"
+        v-if="notificationTypes.length"
         type="primary"
         style="margin-left: 10px"
         @click="notifyTest"
@@ -17,7 +18,7 @@
       </n-button>
     </n-form-item>
 
-    <template v-if="config.notification.setting.type === NotificationType.mail">
+    <template v-if="hasNotificationType(NotificationType.mail)">
       <n-form-item>
         <template #label>
           <span class="inline-flex">
@@ -42,7 +43,9 @@
         <template #label>
           <span class="inline-flex"> TLS </span>
         </template>
-        <n-switch v-model:value="config.notification.setting.mail.secure" /> </n-form-item
+        <n-switch
+          v-model:value="config.notification.setting.mail.secure"
+        /> </n-form-item
       ><n-form-item>
         <template #label>
           <span class="inline-flex"> 邮箱账户 </span>
@@ -70,7 +73,7 @@
           placeholder="请输入收件人邮箱"
         ></n-input> </n-form-item
     ></template>
-    <template v-else-if="config.notification.setting.type === NotificationType.server">
+    <template v-if="hasNotificationType(NotificationType.server)">
       <n-form-item>
         <template #label>
           <span class="inline-flex">
@@ -85,7 +88,7 @@
           show-password-on="click"
         ></n-input> </n-form-item
     ></template>
-    <template v-else-if="config.notification.setting.type === NotificationType.tg">
+    <template v-if="hasNotificationType(NotificationType.tg)">
       <n-form-item>
         <template #label>
           <span class="inline-flex"> token </span>
@@ -119,7 +122,7 @@
         ></n-input>
       </n-form-item>
     </template>
-    <template v-else-if="config.notification.setting.type === NotificationType.ntfy">
+    <template v-if="hasNotificationType(NotificationType.ntfy)">
       <n-form-item>
         <template #label>
           <span class="inline-flex"> 服务器地址 </span>
@@ -137,7 +140,7 @@
           placeholder="请输入topic"
         ></n-input> </n-form-item
     ></template>
-    <template v-else-if="config.notification.setting.type === NotificationType.allInOne">
+    <template v-if="hasNotificationType(NotificationType.allInOne)">
       <n-form-item>
         <template #label>
           <Tip
@@ -160,10 +163,13 @@
           show-password-on="click"
         ></n-input> </n-form-item
     ></template>
-    <template v-else-if="config.notification.setting.type === NotificationType.customHttp">
+    <template v-if="hasNotificationType(NotificationType.customHttp)">
       <n-form-item>
         <template #label>
-          <Tip tip="支持{{title}}和{{desc}}占位符，GET请求会自动URL编码" text="请求URL"></Tip>
+          <Tip
+            tip="支持{{title}}和{{desc}}占位符，GET请求会自动URL编码"
+            text="请求URL"
+          ></Tip>
         </template>
         <n-input
           v-model:value="config.notification.setting.customHttp.url"
@@ -199,12 +205,47 @@
       </n-form-item>
       <n-form-item>
         <template #label>
-          <Tip tip="自定义请求头，每行一个，格式为key: value" text="请求头"></Tip>
+          <Tip
+            tip="自定义请求头，每行一个，格式为key: value"
+            text="请求头"
+          ></Tip>
         </template>
         <n-input
           v-model:value="config.notification.setting.customHttp.headers"
           type="textarea"
           placeholder="请输入请求头"
+        ></n-input>
+      </n-form-item>
+    </template>
+    <template v-if="hasNotificationType(NotificationType.feishuBot)">
+      <n-form-item>
+        <template #label>
+          <Tip
+            tip="飞书群聊中添加自定义机器人后复制 Webhook 地址"
+            text="Webhook 地址"
+          ></Tip>
+        </template>
+        <n-input
+          v-model:value="config.notification.setting.feishuBot.webhookUrl"
+          type="password"
+          placeholder="请输入飞书机器人 Webhook 地址"
+          show-password-on="click"
+        ></n-input>
+      </n-form-item>
+    </template>
+    <template v-if="hasNotificationType(NotificationType.wecomBot)">
+      <n-form-item>
+        <template #label>
+          <Tip
+            tip="企业微信群聊中添加群机器人后复制 Webhook 地址"
+            text="Webhook 地址"
+          ></Tip>
+        </template>
+        <n-input
+          v-model:value="config.notification.setting.wecomBot.webhookUrl"
+          type="password"
+          placeholder="请输入企业微信机器人 Webhook 地址"
+          show-password-on="click"
         ></n-input>
       </n-form-item>
     </template>
@@ -252,7 +293,9 @@
       </n-checkbox-group>
     </n-form-item>
     <n-form-item label="稿件审核状态">
-      <n-checkbox-group v-model:value="config.notification.task.mediaStatusCheck">
+      <n-checkbox-group
+        v-model:value="config.notification.task.mediaStatusCheck"
+      >
         <n-space item-style="display: flex;">
           <n-checkbox value="success" label="通过" />
           <n-checkbox value="failure" label="失败" />
@@ -269,11 +312,12 @@
     </n-form-item>
     <n-form-item label="直播通知">
       <n-select
-        v-model:value="config.notification.taskNotificationType.liveStart"
+        v-model:value="liveNotificationTypes"
         :options="typeOptions"
+        multiple
         placeholder="请选择通知类型，不选则使用全局通知类型"
         clearable
-        style="width: 200px"
+        style="width: 360px"
       />
     </n-form-item>
     <n-form-item>
@@ -283,7 +327,9 @@
           text="硬盘容量检测"
         ></Tip>
       </template>
-      <n-checkbox-group v-model:value="config.notification.task.diskSpaceCheck.values">
+      <n-checkbox-group
+        v-model:value="config.notification.task.diskSpaceCheck.values"
+      >
         <n-space item-style="display: flex;">
           <n-checkbox value="bilirecorder" label="录播姬工作目录" />
           <n-checkbox value="bililiveTools" label="直播录制目录" />
@@ -304,9 +350,12 @@
 <script setup lang="ts">
 import { configApi } from "@renderer/apis";
 import { cloneDeep } from "lodash-es";
+import { computed } from "vue";
 import { NotificationType } from "@biliLive-tools/shared/enum.js";
 
 import type { AppConfig } from "@biliLive-tools/types";
+
+type NotifyType = NonNullable<AppConfig["notification"]["setting"]["type"]>;
 
 const config = defineModel<AppConfig>("data", {
   default: () => {},
@@ -320,16 +369,51 @@ const typeOptions = [
   { value: NotificationType.ntfy, label: "ntfy" },
   { value: NotificationType.allInOne, label: "push all in cloud" },
   { value: NotificationType.customHttp, label: "自定义HTTP" },
+  { value: NotificationType.feishuBot, label: "飞书机器人" },
+  { value: NotificationType.wecomBot, label: "企业微信机器人" },
 ];
 
 const notice = useNotification();
+
+const normalizeNotifyTypes = (
+  value?: NotifyType | NotifyType[],
+): NotifyType[] => {
+  if (Array.isArray(value)) return value.filter(Boolean);
+  return value ? [value] : [];
+};
+
+const notificationTypes = computed<NotifyType[]>({
+  get() {
+    const types = normalizeNotifyTypes(config.value.notification.setting.types);
+    if (types.length) return types;
+    return normalizeNotifyTypes(config.value.notification.setting.type);
+  },
+  set(value) {
+    config.value.notification.setting.types = value;
+    config.value.notification.setting.type = value[0];
+  },
+});
+
+const liveNotificationTypes = computed<NotifyType[]>({
+  get() {
+    return normalizeNotifyTypes(
+      config.value.notification.taskNotificationType.liveStart,
+    );
+  },
+  set(value) {
+    config.value.notification.taskNotificationType.liveStart = value;
+  },
+});
+
+const hasNotificationType = (type: NotifyType) =>
+  notificationTypes.value.includes(type);
 
 const notifyTest = async () => {
   await configApi.notifyTest(
     "我是一条测试信息",
     "我是一条测试信息",
     cloneDeep(config.value),
-    config.value.notification.setting.type,
+    notificationTypes.value,
   );
   notice.info({
     title: "已尝试发送测试信息，请注意查收",

--- a/packages/shared/src/enum.ts
+++ b/packages/shared/src/enum.ts
@@ -195,6 +195,7 @@ export const APP_DEFAULT_CONFIG: AppConfig = {
     },
     setting: {
       type: undefined,
+      types: [],
       server: {
         key: "",
       },
@@ -225,9 +226,15 @@ export const APP_DEFAULT_CONFIG: AppConfig = {
         body: "",
         headers: "",
       },
+      feishuBot: {
+        webhookUrl: "",
+      },
+      wecomBot: {
+        webhookUrl: "",
+      },
     },
     taskNotificationType: {
-      liveStart: "system",
+      liveStart: ["system"],
     },
   },
   sync: {
@@ -348,7 +355,8 @@ export const APP_DEFAULT_CONFIG: AppConfig = {
   },
   recorder: {
     savePath: "",
-    nameRule: "{platform}/{owner}/{year}-{month}-{date} {hour}-{min}-{sec}-{ms} {title}",
+    nameRule:
+      "{platform}/{owner}/{year}-{month}-{date} {hour}-{min}-{sec}-{ms} {title}",
     autoRecord: true,
     quality: "highest",
     line: undefined,

--- a/packages/shared/src/notify.ts
+++ b/packages/shared/src/notify.ts
@@ -11,12 +11,18 @@ import type {
   NotificationNtfyConfig,
   NotificationPushAllInAllConfig,
   NotificationCustomHttpConfig,
+  NotificationFeishuBotConfig,
+  NotificationWeComBotConfig,
 } from "@biliLive-tools/types";
 
 /**
  * 通过Server酱发送通知
  */
-export function sendByServer(title: string, desp: string, options: NotificationServerConfig) {
+export function sendByServer(
+  title: string,
+  desp: string,
+  options: NotificationServerConfig,
+) {
   if (!options.key) {
     throw new Error("Server酱key不能为空");
   }
@@ -26,8 +32,18 @@ export function sendByServer(title: string, desp: string, options: NotificationS
 /**
  * 通过邮件发送通知
  */
-export async function sendByMail(title: string, desp: string, options: NotificationMailConfig) {
-  if (!options.host || !options.port || !options.user || !options.pass || !options.to) {
+export async function sendByMail(
+  title: string,
+  desp: string,
+  options: NotificationMailConfig,
+) {
+  if (
+    !options.host ||
+    !options.port ||
+    !options.user ||
+    !options.pass ||
+    !options.to
+  ) {
     throw new Error("mail host、port、user、pass、to不能为空");
   }
   const transporter = nodemailer.createTransport({
@@ -54,7 +70,11 @@ export async function sendByMail(title: string, desp: string, options: Notificat
 /**
  * 通过tg发送通知
  */
-export async function sendByTg(title: string, desp: string, options: NotificationTgConfig) {
+export async function sendByTg(
+  title: string,
+  desp: string,
+  options: NotificationTgConfig,
+) {
   if (!options.key || !options.chat_id) {
     throw new Error("tg key或chat_id不能为空");
   }
@@ -104,7 +124,11 @@ export async function sendBySystem(title: string, desp: string) {
 /**
  * ntfy发送通知
  */
-export async function sendByNtfy(title: string, desp: string, options: NotificationNtfyConfig) {
+export async function sendByNtfy(
+  title: string,
+  desp: string,
+  options: NotificationNtfyConfig,
+) {
   const url = `${options.url}`;
   const data = {
     topic: options.topic,
@@ -191,6 +215,78 @@ export async function sendByCustomHttp(
   }
 }
 
+function buildBotText(title: string, desp: string) {
+  return [title, desp].filter(Boolean).join("\n\n");
+}
+
+/**
+ * 通过飞书群机器人发送通知
+ */
+export async function sendByFeishuBot(
+  title: string,
+  desp: string,
+  options: NotificationFeishuBotConfig,
+) {
+  if (!options.webhookUrl) {
+    throw new Error("飞书机器人 Webhook 地址不能为空");
+  }
+
+  const data = {
+    msg_type: "text",
+    content: {
+      text: buildBotText(title, desp),
+    },
+  };
+
+  try {
+    const res = await fetch(options.webhookUrl, {
+      method: "POST",
+      body: JSON.stringify(data),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    log.info("sendByFeishuBot res", res);
+  } catch (e) {
+    log.error("sendByFeishuBot error", e);
+    throw e;
+  }
+}
+
+/**
+ * 通过企业微信群机器人发送通知
+ */
+export async function sendByWeComBot(
+  title: string,
+  desp: string,
+  options: NotificationWeComBotConfig,
+) {
+  if (!options.webhookUrl) {
+    throw new Error("企业微信机器人 Webhook 地址不能为空");
+  }
+
+  const data = {
+    msgtype: "text",
+    text: {
+      content: buildBotText(title, desp),
+    },
+  };
+
+  try {
+    const res = await fetch(options.webhookUrl, {
+      method: "POST",
+      body: JSON.stringify(data),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    log.info("sendByWeComBot res", res);
+  } catch (e) {
+    log.error("sendByWeComBot error", e);
+    throw e;
+  }
+}
+
 type TaskType =
   | "liveStart"
   | "ffmpeg"
@@ -202,24 +298,52 @@ type TaskType =
   | "diskSpaceCheck"
   | "sync";
 
-export function send(title: string, desp: string, options?: { type?: TaskType }) {
+type NotifyType = AppConfig["notification"]["setting"]["type"];
+type NotifyTypeSetting = NotifyType | NotifyType[];
+
+function normalizeNotifyTypes(notifyType?: NotifyTypeSetting): NotifyType[] {
+  if (Array.isArray(notifyType)) {
+    return notifyType.filter(Boolean);
+  }
+  return notifyType ? [notifyType] : [];
+}
+
+function getDefaultNotifyTypes(config: AppConfig): NotifyType[] {
+  const setting = config?.notification?.setting;
+  const types = normalizeNotifyTypes(setting?.types);
+  if (types.length) return types;
+  return normalizeNotifyTypes(setting?.type);
+}
+
+export function send(
+  title: string,
+  desp: string,
+  options?: { type?: TaskType },
+) {
   const config = appConfig.getAll();
-  let notifyType = config?.notification?.setting?.type;
+  let notifyType: NotifyTypeSetting | undefined;
 
   if (options?.type) {
     if (config?.notification?.taskNotificationType[options.type]) {
       notifyType = config?.notification?.taskNotificationType[options.type];
     }
   }
-  log.debug("send notify", { title, desp, notifyType });
+  const notifyTypes = normalizeNotifyTypes(notifyType);
+  log.debug("send notify", {
+    title,
+    desp,
+    notifyTypes: notifyTypes.length
+      ? notifyTypes
+      : getDefaultNotifyTypes(config),
+  });
   return _send(title, desp, config, notifyType);
 }
 
-export async function _send(
+async function sendToType(
   title: string,
   desp: string,
   appConfig: AppConfig,
-  notifyType: AppConfig["notification"]["setting"]["type"],
+  notifyType: NotifyType,
 ): Promise<any | void> {
   switch (notifyType) {
     case "server":
@@ -238,12 +362,65 @@ export async function _send(
       await sendByNtfy(title, desp, appConfig?.notification?.setting?.ntfy);
       break;
     case "allInOne":
-      await sendByAllInOne(title, desp, appConfig?.notification?.setting?.allInOne);
+      await sendByAllInOne(
+        title,
+        desp,
+        appConfig?.notification?.setting?.allInOne,
+      );
       break;
     case "customHttp":
-      await sendByCustomHttp(title, desp, appConfig?.notification?.setting?.customHttp);
+      await sendByCustomHttp(
+        title,
+        desp,
+        appConfig?.notification?.setting?.customHttp,
+      );
+      break;
+    case "feishuBot":
+      await sendByFeishuBot(
+        title,
+        desp,
+        appConfig?.notification?.setting?.feishuBot,
+      );
+      break;
+    case "wecomBot":
+      await sendByWeComBot(
+        title,
+        desp,
+        appConfig?.notification?.setting?.wecomBot,
+      );
       break;
   }
+}
+
+export async function _send(
+  title: string,
+  desp: string,
+  appConfig: AppConfig,
+  notifyType?: NotifyTypeSetting,
+): Promise<any[] | void> {
+  const notifyTypes = normalizeNotifyTypes(notifyType);
+  const targetTypes = notifyTypes.length
+    ? notifyTypes
+    : getDefaultNotifyTypes(appConfig);
+  const results: any[] = [];
+  const errors: Array<{ type: NotifyType; error: unknown }> = [];
+
+  for (const type of targetTypes) {
+    try {
+      results.push(await sendToType(title, desp, appConfig, type));
+    } catch (error) {
+      log.error("send notify error", { type, error });
+      errors.push({ type, error });
+    }
+  }
+
+  if (errors.length) {
+    throw new Error(
+      `通知发送失败：${errors.map((item) => item.type).join(", ")}`,
+    );
+  }
+
+  return results;
 }
 
 export const sendNotify = send;

--- a/packages/shared/src/recorder/index.ts
+++ b/packages/shared/src/recorder/index.ts
@@ -28,7 +28,7 @@ import {
   sendExternalEventRequest,
 } from "../utils/index.js";
 import RecorderConfig from "./config.js";
-import { sendBySystem, send } from "../notify.js";
+import { _send, sendBySystem } from "../notify.js";
 import { danmaReport, parseDanmu } from "../danmu/index.js";
 
 import type { AppConfig } from "../config.js";
@@ -71,34 +71,68 @@ const getRecorderExternalBase = (recorder: RecorderExternalSource) => {
   };
 };
 
-const sendRecorderExternalEvent = async (type: string, data: Record<string, unknown>) => {
+const sendRecorderExternalEvent = async (
+  type: string,
+  data: Record<string, unknown>,
+) => {
   await sendExternalEventRequest(type, data);
 };
+
+type NotifyType = NonNullable<AppConfigType["notification"]["setting"]["type"]>;
+
+function normalizeNotifyTypes(
+  notifyType?: NotifyType | NotifyType[],
+): NotifyType[] {
+  if (Array.isArray(notifyType)) return notifyType.filter(Boolean);
+  return notifyType ? [notifyType] : [];
+}
+
+function getLiveNotifyTypes(globalConfig: AppConfigType): NotifyType[] {
+  const taskNotifyType =
+    globalConfig?.notification?.taskNotificationType["liveStart"];
+  const taskNotifyTypes = normalizeNotifyTypes(taskNotifyType);
+  if (taskNotifyTypes.length) return taskNotifyTypes;
+
+  const setting = globalConfig?.notification?.setting;
+  return normalizeNotifyTypes(setting?.types).length
+    ? normalizeNotifyTypes(setting?.types)
+    : normalizeNotifyTypes(setting?.type);
+}
 
 async function sendStartLiveNotification(
   appConfig: AppConfig,
   recorder: Recorder,
   config: RecorderConfigType,
 ) {
-  const name = recorder?.liveInfo?.owner ? recorder.liveInfo.owner : config.remarks;
+  const name = recorder?.liveInfo?.owner
+    ? recorder.liveInfo.owner
+    : config.remarks;
   const title = `${name}(${config.channelId}) 正在直播`;
 
   const globalConfig = appConfig.getAll();
-  let notifyType = globalConfig?.notification?.setting?.type;
-  if (globalConfig?.notification?.taskNotificationType["liveStart"]) {
-    notifyType = globalConfig?.notification?.taskNotificationType["liveStart"];
-  }
+  const notifyTypes = getLiveNotifyTypes(globalConfig);
 
-  if (notifyType === "system") {
-    const event = await sendBySystem(title, `${recorder?.liveInfo?.title}\n点击打开直播间`);
+  if (notifyTypes.includes("system")) {
+    const event = await sendBySystem(
+      title,
+      `${recorder?.liveInfo?.title}\n点击打开直播间`,
+    );
     // @ts-ignore
     const { shell } = await import("electron");
     event?.on("click", () => {
       const url = recorder.getChannelURL();
       shell.openExternal(url);
     });
-  } else {
-    await send(title, `标题：${recorder?.liveInfo?.title}`, { type: "liveStart" });
+  }
+
+  const nonSystemNotifyTypes = notifyTypes.filter((type) => type !== "system");
+  if (nonSystemNotifyTypes.length) {
+    await _send(
+      title,
+      `标题：${recorder?.liveInfo?.title}`,
+      globalConfig,
+      nonSystemNotifyTypes,
+    );
   }
 }
 
@@ -119,19 +153,26 @@ async function sendEndLiveNotification(
     return;
   }
 
-  const name = recorder?.liveInfo?.owner ? recorder.liveInfo.owner : config.remarks;
+  const name = recorder?.liveInfo?.owner
+    ? recorder.liveInfo.owner
+    : config.remarks;
   const title = `${name}(${config.channelId}) 录制已停止`;
 
   const globalConfig = appConfig.getAll();
-  let notifyType = globalConfig?.notification?.setting?.type;
-  if (globalConfig?.notification?.taskNotificationType["liveStart"]) {
-    notifyType = globalConfig?.notification?.taskNotificationType["liveStart"];
+  const notifyTypes = getLiveNotifyTypes(globalConfig);
+
+  if (notifyTypes.includes("system")) {
+    sendBySystem(title, "");
   }
 
-  if (notifyType === "system") {
-    sendBySystem(title, "");
-  } else {
-    await send(title, `标题：${recorder?.liveInfo?.title}`, { type: "liveStart" });
+  const nonSystemNotifyTypes = notifyTypes.filter((type) => type !== "system");
+  if (nonSystemNotifyTypes.length) {
+    await _send(
+      title,
+      `标题：${recorder?.liveInfo?.title}`,
+      globalConfig,
+      nonSystemNotifyTypes,
+    );
   }
 
   // 更新最后通知时间
@@ -192,7 +233,10 @@ export async function createRecorderManager(appConfig: AppConfig) {
    * 构建manager配置项
    */
   async function buildManagerOptions(config: AppConfigType) {
-    const savePathRule = path.join(config?.recorder?.savePath, config?.recorder?.nameRule);
+    const savePathRule = path.join(
+      config?.recorder?.savePath,
+      config?.recorder?.nameRule,
+    );
     const autoCheckInterval = config?.recorder?.checkInterval ?? 60;
     const maxThreadCount = config?.recorder?.maxThreadCount ?? 3;
     const waitTime = config?.recorder?.waitTime ?? 0;
@@ -207,27 +251,36 @@ export async function createRecorderManager(appConfig: AppConfig) {
       }
     > = {
       [providerForBiliBili.id]: {
-        autoCheckInterval: (config?.recorder?.bilibili.checkInterval ?? autoCheckInterval) * 1000,
-        maxThreadCount: config?.recorder?.bilibili.maxThreadCount ?? maxThreadCount,
+        autoCheckInterval:
+          (config?.recorder?.bilibili.checkInterval ?? autoCheckInterval) *
+          1000,
+        maxThreadCount:
+          config?.recorder?.bilibili.maxThreadCount ?? maxThreadCount,
         waitTime: config?.recorder?.bilibili.waitTime ?? waitTime,
       },
       [providerForDouYu.id]: {
-        autoCheckInterval: (config?.recorder?.douyu.checkInterval ?? autoCheckInterval) * 1000,
-        maxThreadCount: config?.recorder?.douyu.maxThreadCount ?? maxThreadCount,
+        autoCheckInterval:
+          (config?.recorder?.douyu.checkInterval ?? autoCheckInterval) * 1000,
+        maxThreadCount:
+          config?.recorder?.douyu.maxThreadCount ?? maxThreadCount,
         waitTime: config?.recorder?.douyu.waitTime ?? waitTime,
       },
       [providerForHuYa.id]: {
-        autoCheckInterval: (config?.recorder?.huya.checkInterval ?? autoCheckInterval) * 1000,
+        autoCheckInterval:
+          (config?.recorder?.huya.checkInterval ?? autoCheckInterval) * 1000,
         maxThreadCount: config?.recorder?.huya.maxThreadCount ?? maxThreadCount,
         waitTime: config?.recorder?.huya.waitTime ?? waitTime,
       },
       [providerForDouYin.id]: {
-        autoCheckInterval: (config?.recorder?.douyin.checkInterval ?? autoCheckInterval) * 1000,
-        maxThreadCount: config?.recorder?.douyin.maxThreadCount ?? maxThreadCount,
+        autoCheckInterval:
+          (config?.recorder?.douyin.checkInterval ?? autoCheckInterval) * 1000,
+        maxThreadCount:
+          config?.recorder?.douyin.maxThreadCount ?? maxThreadCount,
         waitTime: config?.recorder?.douyin.waitTime ?? waitTime,
       },
       [providerForXHS.id]: {
-        autoCheckInterval: (config?.recorder?.xhs.checkInterval ?? autoCheckInterval) * 1000,
+        autoCheckInterval:
+          (config?.recorder?.xhs.checkInterval ?? autoCheckInterval) * 1000,
         maxThreadCount: config?.recorder?.xhs.maxThreadCount ?? maxThreadCount,
         waitTime: config?.recorder?.xhs.waitTime ?? waitTime,
       },
@@ -260,7 +313,10 @@ export async function createRecorderManager(appConfig: AppConfig) {
     appConfig: AppConfig,
   ) {
     const config = appConfig.getAll();
-    const savePathRule = path.join(config?.recorder?.savePath, config?.recorder?.nameRule);
+    const savePathRule = path.join(
+      config?.recorder?.savePath,
+      config?.recorder?.nameRule,
+    );
     const autoCheckInterval = config?.recorder?.checkInterval ?? 60;
     const maxThreadCount = config?.recorder?.maxThreadCount ?? 3;
     const waitTime = config?.recorder?.waitTime ?? 0;
@@ -271,7 +327,8 @@ export async function createRecorderManager(appConfig: AppConfig) {
     manager.waitTime = waitTime;
     manager.savePathRule = savePathRule;
     manager.biliBatchQuery = config?.recorder?.bilibili.useBatchQuery ?? false;
-    manager.recordRetryImmediately = config?.recorder?.recordRetryImmediately ?? false;
+    manager.recordRetryImmediately =
+      config?.recorder?.recordRetryImmediately ?? false;
 
     const managerOptions = await buildManagerOptions(config);
 
@@ -290,7 +347,9 @@ export async function createRecorderManager(appConfig: AppConfig) {
 
     for (const recorderOpts of recorderConfig.list()) {
       try {
-        const recorder = manager.recorders.find((item) => item.id === recorderOpts.id);
+        const recorder = manager.recorders.find(
+          (item) => item.id === recorderOpts.id,
+        );
         if (recorder == null) continue;
 
         await updateRecorder(recorder, recorderOpts);
@@ -374,52 +433,63 @@ export async function createRecorderManager(appConfig: AppConfig) {
   // manager.on("RecordSegment", (debug) => {
   //   console.error("Manager segment", debug);
   // });
-  manager.on("videoFileCreated", async ({ recorder, filename, rawFilename }) => {
-    logger.info("Manager videoFileCreated", { recorder, filename, rawFilename });
-    const videoStartTime = new Date();
-    const liveStartTime = recorder.liveInfo?.liveStartTime;
+  manager.on(
+    "videoFileCreated",
+    async ({ recorder, filename, rawFilename }) => {
+      logger.info("Manager videoFileCreated", {
+        recorder,
+        filename,
+        rawFilename,
+      });
+      const videoStartTime = new Date();
+      const liveStartTime = recorder.liveInfo?.liveStartTime;
 
-    if (!recorder.liveInfo) {
-      logger.error("Manager videoFileCreated Error", { recorder, filename, rawFilename });
-      return;
-    }
-    const data = recorderConfig.get(recorder.id);
+      if (!recorder.liveInfo) {
+        logger.error("Manager videoFileCreated Error", {
+          recorder,
+          filename,
+          rawFilename,
+        });
+        return;
+      }
+      const data = recorderConfig.get(recorder.id);
 
-    data?.sendToWebhook &&
-      axios.post(
-        `http://127.0.0.1:${config.port}/webhook/custom`,
-        {
-          event: "FileOpening",
-          filePath: filename,
-          roomId: recorder.channelId,
-          time: videoStartTime.toISOString(),
-          title: recorder.liveInfo.title,
-          username: recorder.liveInfo.owner,
-          platform: recorder.providerId.toLowerCase(),
-          software: "biliLive-tools",
-        },
-        {
-          proxy: false,
-        },
-      );
+      data?.sendToWebhook &&
+        axios.post(
+          `http://127.0.0.1:${config.port}/webhook/custom`,
+          {
+            event: "FileOpening",
+            filePath: filename,
+            roomId: recorder.channelId,
+            time: videoStartTime.toISOString(),
+            title: recorder.liveInfo.title,
+            username: recorder.liveInfo.owner,
+            platform: recorder.providerId.toLowerCase(),
+            software: "biliLive-tools",
+          },
+          {
+            proxy: false,
+          },
+        );
 
-    await sendRecorderExternalEvent("file_created", {
-      filePath: filename,
-      roomId: String(recorder.channelId),
-      platform: recorder.providerId,
-    });
+      await sendRecorderExternalEvent("file_created", {
+        filePath: filename,
+        roomId: String(recorder.channelId),
+        platform: recorder.providerId,
+      });
 
-    recordHistory.addWithStreamer({
-      live_start_time: liveStartTime?.getTime(),
-      live_id: recorder?.liveInfo?.liveId,
-      record_start_time: videoStartTime.getTime(),
-      room_id: recorder.channelId,
-      title: recorder.liveInfo.title,
-      video_file: filename,
-      name: recorder.liveInfo.owner,
-      platform: recorder.providerId,
-    });
-  });
+      recordHistory.addWithStreamer({
+        live_start_time: liveStartTime?.getTime(),
+        live_id: recorder?.liveInfo?.liveId,
+        record_start_time: videoStartTime.getTime(),
+        room_id: recorder.channelId,
+        title: recorder.liveInfo.title,
+        video_file: filename,
+        name: recorder.liveInfo.owner,
+        platform: recorder.providerId,
+      });
+    },
+  );
   manager.on("videoFileCompleted", async ({ recorder, filename, stats }) => {
     logger.info("Manager videoFileCompleted", { recorder, filename, stats });
 
@@ -565,14 +635,20 @@ export async function createRecorderManager(appConfig: AppConfig) {
     }
 
     const xmlFile = replaceExtName(filename, ".xml");
-    if (config.recorder.saveDanma2DB && xmlFile && (await fs.pathExists(xmlFile))) {
+    if (
+      config.recorder.saveDanma2DB &&
+      xmlFile &&
+      (await fs.pathExists(xmlFile))
+    ) {
       const history = recordHistory.getRecord({
         file: filename,
         live_id: liveId,
       });
       if (!history) return;
       logger.info("写入弹幕文件：", xmlFile);
-      const { danmu, sc, gift, guard } = await parseDanmu(replaceExtName(filename, ".xml"));
+      const { danmu, sc, gift, guard } = await parseDanmu(
+        replaceExtName(filename, ".xml"),
+      );
       const result: {
         record_id: number;
         ts: number;
@@ -660,12 +736,17 @@ export async function createRecorderManager(appConfig: AppConfig) {
   setTimeout(() => {
     // 转异步，避免阻塞
     const data = recordHistory.getLastRecordTimesByChannels(
-      manager.recorders.map((r) => ({ channelId: r.channelId, providerId: r.providerId })),
+      manager.recorders.map((r) => ({
+        channelId: r.channelId,
+        providerId: r.providerId,
+      })),
     );
     // console.log("获取上次录制时间完成：", data);
     for (const recorder of manager.recorders) {
       const record = data.find(
-        (item) => item.channelId === recorder.channelId && item.providerId === recorder.providerId,
+        (item) =>
+          item.channelId === recorder.channelId &&
+          item.providerId === recorder.providerId,
       );
       if (record && record.lastRecordTime) {
         if (!recorder.extra) recorder.extra = {};
@@ -682,7 +763,8 @@ export async function createRecorderManager(appConfig: AppConfig) {
       if (
         recorders.findIndex(
           (item) =>
-            item.channelId === recorder.channelId && item.providerId === recorder.providerId,
+            item.channelId === recorder.channelId &&
+            item.providerId === recorder.providerId,
         ) !== -1
       ) {
         return null;
@@ -704,7 +786,9 @@ export async function createRecorderManager(appConfig: AppConfig) {
       }
       return recoder;
     },
-    updateRecorder: async (args: Omit<RecorderConfigType, "channelId" | "providerId">) => {
+    updateRecorder: async (
+      args: Omit<RecorderConfigType, "channelId" | "providerId">,
+    ) => {
       const { id } = args;
       const recorder = manager.recorders.find((item) => item.id === id);
       if (recorder == null) return null;

--- a/packages/shared/test/notify.test.ts
+++ b/packages/shared/test/notify.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchMock = vi.fn();
+
+vi.stubGlobal("fetch", fetchMock);
+
+const logger = vi.hoisted(() => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock("../src/utils/log.js", () => ({
+  default: logger,
+}));
+
+import { APP_DEFAULT_CONFIG } from "../src/enum.js";
+import { _send, sendByFeishuBot, sendByWeComBot } from "../src/notify.js";
+
+describe("notify bot senders", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockResolvedValue({ ok: true });
+  });
+
+  it("sends text message to feishu bot webhook", async () => {
+    await sendByFeishuBot(
+      "直播总结已生成",
+      "飞书文档：https://feishu.cn/docx/doc",
+      {
+        webhookUrl: "https://open.feishu.cn/open-apis/bot/v2/hook/token",
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://open.feishu.cn/open-apis/bot/v2/hook/token",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          msg_type: "text",
+          content: {
+            text: "直播总结已生成\n\n飞书文档：https://feishu.cn/docx/doc",
+          },
+        }),
+      }),
+    );
+  });
+
+  it("sends text message to enterprise wechat bot webhook", async () => {
+    await sendByWeComBot(
+      "直播总结已生成",
+      "Notion：https://www.notion.so/0123",
+      {
+        webhookUrl:
+          "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=token",
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=token",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          msgtype: "text",
+          text: {
+            content: "直播总结已生成\n\nNotion：https://www.notion.so/0123",
+          },
+        }),
+      }),
+    );
+  });
+});
+
+describe("notify dispatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockResolvedValue({ ok: true });
+  });
+
+  it("sends one notification to every configured notification type", async () => {
+    const config = {
+      ...APP_DEFAULT_CONFIG,
+      notification: {
+        ...APP_DEFAULT_CONFIG.notification,
+        setting: {
+          ...APP_DEFAULT_CONFIG.notification.setting,
+          feishuBot: {
+            webhookUrl: "https://open.feishu.cn/open-apis/bot/v2/hook/token",
+          },
+          wecomBot: {
+            webhookUrl:
+              "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=token",
+          },
+        },
+      },
+    };
+
+    await _send("标题", "内容", config, ["feishuBot", "wecomBot"]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://open.feishu.cn/open-apis/bot/v2/hook/token",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=token",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("attempts later notification types when an earlier one fails", async () => {
+    const config = {
+      ...APP_DEFAULT_CONFIG,
+      notification: {
+        ...APP_DEFAULT_CONFIG.notification,
+        setting: {
+          ...APP_DEFAULT_CONFIG.notification.setting,
+          feishuBot: {
+            webhookUrl: "https://open.feishu.cn/open-apis/bot/v2/hook/token",
+          },
+          wecomBot: {
+            webhookUrl:
+              "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=token",
+          },
+        },
+      },
+    };
+    fetchMock
+      .mockRejectedValueOnce(new Error("feishu failed"))
+      .mockResolvedValueOnce({ ok: true });
+
+    await expect(
+      _send("标题", "内容", config, ["feishuBot", "wecomBot"]),
+    ).rejects.toThrow("通知发送失败：feishuBot");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=token",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -364,8 +364,29 @@ export interface NotificationCustomHttpConfig {
   headers?: string;
 }
 
+/**
+ * 飞书群机器人通知配置
+ */
+export interface NotificationFeishuBotConfig {
+  webhookUrl: string;
+}
+
+/**
+ * 企业微信群机器人通知配置
+ */
+export interface NotificationWeComBotConfig {
+  webhookUrl: string;
+}
+
 export type Theme = "system" | "light" | "dark";
-type FormatName = "auto" | "flv" | "hls" | "fmp4" | "flv_only" | "hls_only" | "fmp4_only";
+type FormatName =
+  | "auto"
+  | "flv"
+  | "hls"
+  | "fmp4"
+  | "flv_only"
+  | "hls_only"
+  | "fmp4_only";
 type CodecName = "auto" | "avc" | "hevc" | "avc_only" | "hevc_only";
 
 interface RecorderCheckConfig {
@@ -568,7 +589,10 @@ export interface Recorder {
   /** 调试等级 */
   debugLevel: "none" | "basic" | "verbose";
   /** API类型，仅抖音 */
-  api: HuyaRecorderConfig["api"] | DouyinRecorderConfig["api"] | DouyuRecorderConfig["api"];
+  api:
+    | HuyaRecorderConfig["api"]
+    | DouyinRecorderConfig["api"]
+    | DouyuRecorderConfig["api"];
   /** 自定义host */
   customHost?: string;
   // 不跟随全局配置字段
@@ -679,7 +703,18 @@ export interface AppConfig {
     /** 通知配置项 */
     setting: {
       // 通知类型，支持server酱和邮件
-      type?: "server" | "mail" | "tg" | "system" | "ntfy" | "allInOne" | "customHttp";
+      type?:
+        | "server"
+        | "mail"
+        | "tg"
+        | "system"
+        | "ntfy"
+        | "allInOne"
+        | "customHttp"
+        | "feishuBot"
+        | "wecomBot";
+      /** 通知类型，支持同时配置多个；未配置时回退到 type */
+      types?: Array<NonNullable<AppConfig["notification"]["setting"]["type"]>>;
       // server酱key
       server: NotificationServerConfig;
       mail: NotificationMailConfig;
@@ -687,9 +722,13 @@ export interface AppConfig {
       ntfy: NotificationNtfyConfig;
       allInOne: NotificationPushAllInAllConfig;
       customHttp: NotificationCustomHttpConfig;
+      feishuBot: NotificationFeishuBotConfig;
+      wecomBot: NotificationWeComBotConfig;
     };
     taskNotificationType: {
-      liveStart: AppConfig["notification"]["setting"]["type"];
+      liveStart:
+        | AppConfig["notification"]["setting"]["type"]
+        | Array<NonNullable<AppConfig["notification"]["setting"]["type"]>>;
     };
   };
   // 同步
@@ -890,7 +929,13 @@ export interface Progress {
 // export interface OpenDialogOptions extends ElectronOpenDialogOptions {
 //   multi?: boolean;
 // }
-export type audioCodec = "copy" | "aac" | "ac3" | "flac" | "libopus" | "libmp3lame";
+export type audioCodec =
+  | "copy"
+  | "aac"
+  | "ac3"
+  | "flac"
+  | "libopus"
+  | "libmp3lame";
 export type VideoCodec =
   | "copy"
   | "libx264"


### PR DESCRIPTION
## Summary
- Allow notification settings to select multiple channels at once while keeping legacy `type` fallback.
- Send notifications to all selected channels and continue attempting later channels if one fails.
- Update the settings UI and live notification override to support multi-select channels.

## Validation
- `pnpm --filter @biliLive-tools/shared test`
- `pnpm --filter @biliLive-tools/shared typecheck`
- `pnpm --filter biliLive-tools typecheck`
