### PR TITLE
feat(notification): 支持自定义 HTTP / push-all-in-cloud 上下文变量

### DIFF
--- a/docs/features/notification.md
+++ b/docs/features/notification.md
@@ -233,6 +233,25 @@ Server酱支持免费推送信息到手机微信，免费账户有限制。
 | API地址 | push-all-in-cloud的API地址 |
 | 密钥    | 访问密钥                   |
 
+### 上下文变量
+
+使用 push-all-in-cloud 时，软件会额外发送一个 `context` 对象，方便服务端做进一步模板渲染或路由。
+
+常见变量包括：
+
+- `title` / `desc` / `desp`
+- `event` / `eventLabel`
+- `roomId` / `platform` / `username` / `liveTitle` / `liveId` / `roomUrl`
+- `taskName` / `taskType` / `taskStatus` / `taskId`
+- `startedAt` / `endedAt` / `durationMs`
+- `filePath` / `filename`
+- `mediaTitle` / `aid`
+- `error` / `output`
+
+::: tip 提示
+如果你使用的是支持模板变量的自建 push-all-in-cloud 服务，可以直接读取这些变量生成更精细的通知，例如区分不同主播、房间号、任务类型等。
+:::
+
 ### 故障排除
 
 **无法推送**
@@ -241,6 +260,98 @@ Server酱支持免费推送信息到手机微信，免费账户有限制。
 2. 检查 API 地址是否正确
 3. 检查密钥是否正确
 4. 检查在服务中配置的推送平台是否正常
+
+## 自定义HTTP
+
+自定义HTTP适合将通知接入自己的 Webhook、自动化服务或中转网关。
+
+### 配置项
+
+| 配置项   | 说明 |
+| -------- | ---- |
+| 请求URL  | 支持模板变量，GET 请求会自动对变量进行 URL 编码 |
+| 请求方法 | 支持 `GET`、`POST`、`PUT` |
+| 请求体   | 支持模板变量 |
+| 请求头   | 每行一个 `key: value`，支持模板变量 |
+
+### 支持的模板变量
+
+#### 基础变量
+
+- `{{title}}`
+- `{{desc}}`
+- `{{desp}}`
+- `{{event}}`
+- `{{eventLabel}}`
+
+#### 直播相关
+
+- `{{roomId}}`
+- `{{platform}}`
+- `{{username}}`
+- `{{liveTitle}}`
+- `{{liveId}}`
+- `{{roomUrl}}`
+
+#### 任务相关
+
+- `{{taskName}}`
+- `{{taskType}}`
+- `{{taskStatus}}`
+- `{{taskId}}`
+- `{{startedAt}}`
+- `{{endedAt}}`
+- `{{durationMs}}`
+- `{{error}}`
+- `{{output}}`
+
+#### 文件/稿件相关
+
+- `{{filePath}}`
+- `{{filename}}`
+- `{{mediaTitle}}`
+- `{{aid}}`
+
+::: tip 提示
+为了便于与其他系统对接，以上变量同时支持驼峰和下划线两种写法，例如 `{{roomId}}` 与 `{{room_id}}` 都可以使用。
+:::
+
+### 示例
+
+#### 1. 发送到自建 push-all-in-cloud
+
+- 请求方法：`POST`
+- 请求URL：`https://example.com/push`
+- 请求体：
+
+```json
+{"title":"[{{platform}}] {{title}}","message":"{{desc}}"}
+```
+
+- 请求头：
+
+```text
+Authorization: Bearer your-token
+Content-Type: application/json
+```
+
+#### 2. 发送到自定义 Webhook
+
+- 请求方法：`POST`
+- 请求URL：`https://example.com/webhook`
+- 请求体：
+
+```json
+{
+  "event": "{{event}}",
+  "eventLabel": "{{eventLabel}}",
+  "roomId": "{{roomId}}",
+  "username": "{{username}}",
+  "taskType": "{{taskType}}",
+  "title": "{{title}}",
+  "desc": "{{desc}}"
+}
+```
 
 ## 通知事件
 

--- a/packages/app/src/renderer/src/pages/setting/NotificationSetting.vue
+++ b/packages/app/src/renderer/src/pages/setting/NotificationSetting.vue
@@ -163,7 +163,10 @@
     <template v-else-if="config.notification.setting.type === NotificationType.customHttp">
       <n-form-item>
         <template #label>
-          <Tip tip="支持{{title}}和{{desc}}占位符，GET请求会自动URL编码" text="请求URL"></Tip>
+          <Tip
+            tip="支持{{title}}、{{desc}}以及上下文占位符（如{{roomId}}、{{username}}、{{platform}}、{{liveTitle}}、{{taskType}}等），GET请求会自动URL编码"
+            text="请求URL"
+          ></Tip>
         </template>
         <n-input
           v-model:value="config.notification.setting.customHttp.url"
@@ -187,7 +190,7 @@
       <n-form-item>
         <template #label>
           <Tip
-            tip="POST/PUT请求的请求体，默认为json，支持{{title}}和{{desc}}占位符"
+            tip="POST/PUT请求的请求体，默认为json，支持{{title}}、{{desc}}以及上下文占位符"
             text="请求体"
           ></Tip>
         </template>

--- a/packages/http/src/routes/config.ts
+++ b/packages/http/src/routes/config.ts
@@ -268,7 +268,31 @@ router.post("/import", upload.single("file"), async (ctx) => {
 
 router.post("/notifyTest", async (ctx) => {
   const { title, desp, options, notifyType } = ctx.request.body;
-  await _send(title, desp, options, notifyType);
+  await _send(title, desp, options, notifyType, {
+    context: {
+      event: "notify_test",
+      eventLabel: "测试通知",
+      roomId: "123456",
+      platform: "Bilibili",
+      username: "测试主播",
+      liveTitle: "这是一条测试直播标题",
+      liveId: "live_test_001",
+      roomUrl: "https://live.bilibili.com/123456",
+      taskName: "上传视频：测试文件.mp4",
+      taskType: "upload",
+      taskStatus: "success",
+      taskId: "task_test_001",
+      filename: "test-file.mp4",
+      filePath: "D:/record/test-file.mp4",
+      mediaTitle: "测试稿件",
+      aid: 123456789,
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      durationMs: 3000,
+      error: "",
+      output: "测试输出内容",
+    },
+  });
   ctx.body = "success";
 });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -110,7 +110,16 @@ const checkDiskSpaceLoop = async () => {
           const diskInfo = await checkDiskSpace(config?.webhook?.recoderFolder);
           if (diskInfo.free < threshold * 1024 * 1024 * 1024) {
             console.warn("录播姬磁盘空间不足，请及时处理");
-            sendNotify("空间不足", "录播姬磁盘空间不足，请及时处理");
+            sendNotify("空间不足", "录播姬磁盘空间不足，请及时处理", {
+              type: "diskSpaceCheck",
+              context: {
+                event: "disk_space_low",
+                eventLabel: "磁盘空间不足",
+                diskTarget: "bilirecorder",
+                thresholdGb: threshold,
+                path: config?.webhook?.recoderFolder,
+              },
+            });
           }
         }
       }
@@ -120,7 +129,16 @@ const checkDiskSpaceLoop = async () => {
           const diskInfo = await checkDiskSpace(config?.recorder?.savePath);
           if (diskInfo.free < threshold * 1024 * 1024 * 1024) {
             console.warn("biliLiveTools录制磁盘空间不足，请及时处理");
-            sendNotify("空间不足", "biliLiveTools录制磁盘空间不足，请及时处理");
+            sendNotify("空间不足", "biliLiveTools录制磁盘空间不足，请及时处理", {
+              type: "diskSpaceCheck",
+              context: {
+                event: "disk_space_low",
+                eventLabel: "磁盘空间不足",
+                diskTarget: "bililiveTools",
+                thresholdGb: threshold,
+                path: config?.recorder?.savePath,
+              },
+            });
           }
         }
       }

--- a/packages/shared/src/notify.ts
+++ b/packages/shared/src/notify.ts
@@ -14,6 +14,84 @@ import type {
 } from "@biliLive-tools/types";
 
 /**
+ * 通知模板上下文支持的值类型
+ */
+type NotificationContextValue = string | number | boolean | null | undefined;
+
+/**
+ * 通知模板上下文
+ */
+export type NotificationContext = Record<string, NotificationContextValue>;
+
+/**
+ * 任务类型
+ */
+type TaskType =
+  | "liveStart"
+  | "ffmpeg"
+  | "danmu"
+  | "upload"
+  | "download"
+  | "douyuDownload"
+  | "mediaStatusCheck"
+  | "diskSpaceCheck"
+  | "sync";
+
+/**
+ * 通知发送选项
+ */
+export type NotificationSendOptions = {
+  type?: TaskType;
+  context?: NotificationContext;
+};
+
+const toTemplateValue = (value: NotificationContextValue) => {
+  if (value === undefined || value === null) {
+    return "";
+  }
+  return String(value);
+};
+
+const toSnakeCase = (key: string) => {
+  return key.replace(/([A-Z])/g, "_$1").toLowerCase();
+};
+
+const appendTemplateValue = (
+  target: Record<string, string>,
+  key: string,
+  value: NotificationContextValue,
+) => {
+  const stringValue = toTemplateValue(value);
+  target[key] = stringValue;
+  const snakeCaseKey = toSnakeCase(key);
+  if (!(snakeCaseKey in target)) {
+    target[snakeCaseKey] = stringValue;
+  }
+};
+
+const buildTemplateContext = (title: string, desp: string, context: NotificationContext = {}) => {
+  const templateContext: Record<string, string> = {};
+  appendTemplateValue(templateContext, "title", title);
+  appendTemplateValue(templateContext, "desc", desp);
+  appendTemplateValue(templateContext, "desp", desp);
+  Object.entries(context).forEach(([key, value]) => {
+    appendTemplateValue(templateContext, key, value);
+  });
+  return templateContext;
+};
+
+const renderTemplate = (
+  template: string,
+  templateContext: Record<string, string>,
+  options: { encode?: boolean } = {},
+) => {
+  return template.replace(/\{\{(\w+)\}\}/g, (_match, key: string) => {
+    const value = templateContext[key] || "";
+    return options.encode ? encodeURIComponent(value) : value;
+  });
+};
+
+/**
  * 通过Server酱发送通知
  */
 export function sendByServer(title: string, desp: string, options: NotificationServerConfig) {
@@ -127,12 +205,16 @@ export async function sendByAllInOne(
   title: string,
   desp: string,
   options: NotificationPushAllInAllConfig,
+  context?: NotificationContext,
 ) {
+  const templateContext = buildTemplateContext(title, desp, context);
   const data = {
+    title,
+    desp,
     message: desp,
-    title: title,
+    context: templateContext,
   };
-  fetch(options.server, {
+  const res = await fetch(options.server, {
     method: "POST",
     body: JSON.stringify(data),
     headers: {
@@ -140,6 +222,7 @@ export async function sendByAllInOne(
       Authorization: `Bearer ${options.key}`,
     },
   });
+  log.info("sendByAllInOne res", res);
 }
 
 /**
@@ -149,11 +232,13 @@ export async function sendByCustomHttp(
   title: string,
   desp: string,
   options: NotificationCustomHttpConfig,
+  context?: NotificationContext,
 ) {
   if (!options.url) {
     throw new Error("自定义HTTP通知URL不能为空");
   }
 
+  const templateContext = buildTemplateContext(title, desp, context);
   let url = options.url;
   let body = options.body || "";
   let headers: Record<string, string> = {};
@@ -164,16 +249,14 @@ export async function sendByCustomHttp(
     for (const line of headerLines) {
       const [key, ...values] = line.split(":");
       if (key && values.length > 0) {
-        headers[key.trim()] = values.join(":").trim();
+        headers[key.trim()] = renderTemplate(values.join(":").trim(), templateContext);
       }
     }
   }
 
   // 替换占位符
-  url = url
-    .replace("{{title}}", encodeURIComponent(title))
-    .replace("{{desc}}", encodeURIComponent(desp));
-  body = body.replace("{{title}}", title).replace("{{desc}}", desp);
+  url = renderTemplate(url, templateContext, { encode: true });
+  body = renderTemplate(body, templateContext);
 
   try {
     const res = await fetch(url, {
@@ -191,18 +274,7 @@ export async function sendByCustomHttp(
   }
 }
 
-type TaskType =
-  | "liveStart"
-  | "ffmpeg"
-  | "danmu"
-  | "upload"
-  | "download"
-  | "douyuDownload"
-  | "mediaStatusCheck"
-  | "diskSpaceCheck"
-  | "sync";
-
-export function send(title: string, desp: string, options?: { type?: TaskType }) {
+export function send(title: string, desp: string, options?: NotificationSendOptions) {
   const config = appConfig.getAll();
   let notifyType = config?.notification?.setting?.type;
 
@@ -211,8 +283,8 @@ export function send(title: string, desp: string, options?: { type?: TaskType })
       notifyType = config?.notification?.taskNotificationType[options.type];
     }
   }
-  log.debug("send notify", { title, desp, notifyType });
-  return _send(title, desp, config, notifyType);
+  log.debug("send notify", { title, desp, notifyType, context: options?.context });
+  return _send(title, desp, config, notifyType, options);
 }
 
 export async function _send(
@@ -220,6 +292,7 @@ export async function _send(
   desp: string,
   appConfig: AppConfig,
   notifyType: AppConfig["notification"]["setting"]["type"],
+  options?: NotificationSendOptions,
 ): Promise<any | void> {
   switch (notifyType) {
     case "server":
@@ -238,10 +311,10 @@ export async function _send(
       await sendByNtfy(title, desp, appConfig?.notification?.setting?.ntfy);
       break;
     case "allInOne":
-      await sendByAllInOne(title, desp, appConfig?.notification?.setting?.allInOne);
+      await sendByAllInOne(title, desp, appConfig?.notification?.setting?.allInOne, options?.context);
       break;
     case "customHttp":
-      await sendByCustomHttp(title, desp, appConfig?.notification?.setting?.customHttp);
+      await sendByCustomHttp(title, desp, appConfig?.notification?.setting?.customHttp, options?.context);
       break;
   }
 }

--- a/packages/shared/src/recorder/index.ts
+++ b/packages/shared/src/recorder/index.ts
@@ -98,7 +98,20 @@ async function sendStartLiveNotification(
       shell.openExternal(url);
     });
   } else {
-    await send(title, `标题：${recorder?.liveInfo?.title}`, { type: "liveStart" });
+    await send(title, `标题：${recorder?.liveInfo?.title}`, {
+      type: "liveStart",
+      context: {
+        event: "live_start",
+        eventLabel: "开播",
+        roomId: String(recorder.channelId),
+        platform: recorder.providerId,
+        username: name,
+        liveTitle: recorder?.liveInfo?.title,
+        liveId: recorder?.liveInfo?.liveId,
+        roomUrl: recorder.getChannelURL(),
+        startedAt: new Date().toISOString(),
+      },
+    });
   }
 }
 
@@ -131,7 +144,20 @@ async function sendEndLiveNotification(
   if (notifyType === "system") {
     sendBySystem(title, "");
   } else {
-    await send(title, `标题：${recorder?.liveInfo?.title}`, { type: "liveStart" });
+    await send(title, `标题：${recorder?.liveInfo?.title}`, {
+      type: "liveStart",
+      context: {
+        event: "live_end",
+        eventLabel: "下播",
+        roomId: String(recorder.channelId),
+        platform: recorder.providerId,
+        username: name,
+        liveTitle: recorder?.liveInfo?.title,
+        liveId: recorder?.liveInfo?.liveId,
+        roomUrl: recorder.getChannelURL(),
+        endedAt: new Date().toISOString(),
+      },
+    });
   }
 
   // 更新最后通知时间

--- a/packages/shared/src/task/bili.ts
+++ b/packages/shared/src/task/bili.ts
@@ -41,7 +41,7 @@ async function sendNotifyWithThrottle(
   title: string,
   desp: string,
   aid: number,
-  options?: { type?: "mediaStatusCheck" },
+  options?: Parameters<typeof sendNotify>[2],
 ) {
   const now = Date.now();
   const lastNotificationTime = notificationCache.get(aid);
@@ -445,7 +445,17 @@ async function biliMediaAction(
             `《${media.title}》稿件审核通过`,
             `请前往B站创作中心查看详情\n稿件名：${media.title}`,
             options.aid!,
-            { type: "mediaStatusCheck" },
+            {
+              type: "mediaStatusCheck",
+              context: {
+                event: "media_status_success",
+                eventLabel: "稿件审核通过",
+                aid: options.aid,
+                mediaTitle: media.title,
+                mediaStatus: status,
+                uid: options.uid,
+              },
+            },
           );
         } catch (error) {
           log.error("发送通知失败", error);
@@ -488,7 +498,18 @@ async function biliMediaAction(
             `《${media.title}》稿件审核未通过`,
             `请前往B站创作中心查看详情\n稿件名：${media.title}\n状态：${media.state_desc}\n状态码：${media.state}`,
             options.aid!,
-            { type: "mediaStatusCheck" },
+            {
+              type: "mediaStatusCheck",
+              context: {
+                event: "media_status_failure",
+                eventLabel: "稿件审核未通过",
+                aid: options.aid,
+                mediaTitle: media.title,
+                mediaStatus: media.state_desc,
+                mediaStateCode: media.state,
+                uid: options.uid,
+              },
+            },
           );
         } catch (error) {
           log.error("发送通知失败", error);

--- a/packages/shared/src/task/core/taskHelpers.ts
+++ b/packages/shared/src/task/core/taskHelpers.ts
@@ -30,37 +30,64 @@ export const sendTaskNotify = (event: NotificationTaskStatus, taskId: string): v
       desp = `${task.name}出错\n\n开始时间：${new Date(task.startTime!).toLocaleString()}\n\n错误信息：${task.error}`;
       break;
   }
+
+  const extraContext =
+    task.extra && typeof task.extra === "object"
+      ? Object.fromEntries(
+          Object.entries(task.extra).filter(([, value]) => {
+            return ["string", "number", "boolean"].includes(typeof value);
+          }),
+        )
+      : {};
+
+  const notifyOptions = {
+    context: {
+      event: event === "success" ? "task_success" : "task_failure",
+      eventLabel: event === "success" ? "任务成功" : "任务失败",
+      taskId: task.taskId,
+      taskName: task.name,
+      taskType: taskType,
+      taskStatus: event,
+      taskOutput: task.output,
+      taskError: task.error ? String(task.error) : "",
+      startedAt: task.startTime ? new Date(task.startTime).toISOString() : "",
+      endedAt: task.endTime ? new Date(task.endTime).toISOString() : "",
+      durationMs: task.getDuration(),
+      ...extraContext,
+    },
+  };
+
   const config = appConfig.getAll();
   const taskConfig = config?.notification?.task;
   switch (taskType) {
     case TaskType.ffmpeg:
       if (taskConfig.ffmpeg.includes(event)) {
-        sendNotify(title, desp);
+        sendNotify(title, desp, notifyOptions);
       }
       break;
     case TaskType.danmu:
       if (taskConfig.danmu.includes(event)) {
-        sendNotify(title, desp);
+        sendNotify(title, desp, notifyOptions);
       }
       break;
     case TaskType.bili:
       if (taskConfig.upload.includes(event)) {
-        sendNotify(title, desp);
+        sendNotify(title, desp, notifyOptions);
       }
       break;
     case TaskType.biliDownload:
       if (taskConfig.download.includes(event)) {
-        sendNotify(title, desp);
+        sendNotify(title, desp, notifyOptions);
       }
       break;
     case TaskType.douyuDownload:
       if (taskConfig.download.includes(event)) {
-        sendNotify(title, desp);
+        sendNotify(title, desp, notifyOptions);
       }
       break;
     case TaskType.sync:
       if (taskConfig.sync.includes(event)) {
-        sendNotify(title, desp);
+        sendNotify(title, desp, notifyOptions);
       }
       break;
   }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -354,13 +354,13 @@ export interface NotificationPushAllInAllConfig {
  * 自定义HTTP通知配置
  */
 export interface NotificationCustomHttpConfig {
-  /** 请求URL */
+  /** 请求URL，支持{{title}}、{{desc}}以及上下文占位符 */
   url: string;
   /** 请求方法 */
   method?: "GET" | "POST" | "PUT";
-  /** 请求体，支持{{title}}和{{desc}}占位符 */
+  /** 请求体，支持{{title}}、{{desc}}以及上下文占位符 */
   body?: string;
-  /** 请求头，每行一个，格式为key: value */
+  /** 请求头，每行一个，格式为key: value，支持占位符 */
   headers?: string;
 }
 


### PR DESCRIPTION
## Summary

Improve the notification system so users can customize downstream payloads with richer variables instead of only `{{title}}` / `{{desc}}`.

## What changed

### 1. Add reusable notification context/template rendering
- introduce `NotificationSendOptions` and `context`
- support both camelCase and snake_case placeholders (e.g. `{{roomId}}` and `{{room_id}}`)

### 2. Enhance Custom HTTP notifications
Custom HTTP now supports context variables in:
- request URL
- request body
- request headers

### 3. Enhance push-all-in-cloud notifications
When using `push-all-in-cloud`, the client now sends:
- `title`
- `desp`
- `message`
- `context`

This allows self-hosted push-all-in-cloud services to render more detailed notifications.

### 4. Enrich built-in notification contexts
Added structured context for:
- live start / live end
- task success / task failure
- media review pass / fail
- disk space alerts
- notify test API sample payload

### 5. Docs / UI hints
- update Custom HTTP tooltip text in settings
- document supported variables and examples in `docs/features/notification.md`

## Why

Right now the notification system is hard to distinguish when multiple rooms or multiple services are running at the same time. This change makes it possible to build messages like:

- `🔴 {{username}} ({{roomId}})`
- `❌ {{taskType}} 失败 | {{username}}`
- custom webhook payloads with `roomId`, `platform`, `liveTitle`, `taskId`, `filePath`, etc.

without breaking existing users.

## Compatibility

Backward compatible:
- existing notification behavior is unchanged if users keep using only `{{title}}` / `{{desc}}`
- existing Custom HTTP configs continue to work
- existing push-all-in-cloud deployments can ignore the extra `context` field

## Verification

Passed:
- `pnpm --filter @biliLive-tools/shared typecheck`
- `pnpm --filter @biliLive-tools/http typecheck`
- `pnpm --filter biliLive-tools typecheck:web`

Tried but blocked by local dependency/export mismatch:
- `pnpm --filter biliLive-tools lint`

The lint failure was:
- `Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './recommended' is not defined by "exports" in @vue/eslint-config-typescript`
