### PR TITLE
修复：防止服务长期运行时内存无界增长

### DIFF
--- a/packages/http/src/routes/sse.ts
+++ b/packages/http/src/routes/sse.ts
@@ -4,6 +4,7 @@ import chokidar from "chokidar";
 import sse from "koa-sse-stream";
 import { handleListTask } from "@biliLive-tools/shared/task/task.js";
 import { musicDetect } from "@biliLive-tools/shared/musicDetector/index.js";
+import type { Message, SerializedRecorder } from "@bililive-tools/manager";
 
 import { config, container } from "../index.js";
 
@@ -75,11 +76,22 @@ router.get(
     const id = ctx.query.id;
 
     const recorderManager = container.resolve("recorderManager");
-    recorderManager.manager.on("Message", ({ recorder, message }) => {
+    const handleMessage = ({
+      recorder,
+      message,
+    }: {
+      recorder: SerializedRecorder<any>;
+      message: Message;
+    }) => {
       if (recorder.id === id) {
         // @ts-ignore
         ctx.sse.send(JSON.stringify(message));
       }
+    };
+    recorderManager.manager.on("Message", handleMessage);
+
+    ctx.req.once("close", () => {
+      recorderManager.manager.off("Message", handleMessage);
     });
   },
 );

--- a/packages/http/src/services/webhook/EventBufferManager.ts
+++ b/packages/http/src/services/webhook/EventBufferManager.ts
@@ -17,7 +17,11 @@ export interface MatchedEventPair {
 interface EventData {
   open?: Options;
   close?: Options;
+  updatedAt: number;
 }
+
+const DEFAULT_EVENT_TTL = 6 * 60 * 60 * 1000;
+const DEFAULT_MAX_EVENTS = 1000;
 
 /**
  * 事件缓冲管理器
@@ -28,6 +32,13 @@ export class EventBufferManager extends EventEmitter<{
 }> {
   // 事件缓冲区,同时保存 open 和 close 事件
   private events: Map<string, EventData> = new Map();
+
+  constructor(
+    private readonly eventTtl = DEFAULT_EVENT_TTL,
+    private readonly maxEvents = DEFAULT_MAX_EVENTS,
+  ) {
+    super();
+  }
 
   /**
    * 添加事件到缓冲区
@@ -49,11 +60,14 @@ export class EventBufferManager extends EventEmitter<{
   private setEvent(event: Options, type: "open" | "close"): void {
     const filePath = event.filePath;
 
+    this.pruneExpiredEvents();
+
     // 获取或创建事件数据
     let eventData = this.events.get(filePath);
     if (!eventData) {
-      eventData = {};
+      eventData = { updatedAt: Date.now() };
     }
+    eventData.updatedAt = Date.now();
 
     // 存储事件
     if (type === "open") {
@@ -66,8 +80,26 @@ export class EventBufferManager extends EventEmitter<{
 
     // 更新到 Map 中
     this.events.set(filePath, eventData);
+    this.enforceCapacity();
 
     this.emitPair();
+  }
+
+  private pruneExpiredEvents(): void {
+    const expireBefore = Date.now() - this.eventTtl;
+    for (const [filePath, eventData] of this.events) {
+      if (eventData.updatedAt <= expireBefore) {
+        this.events.delete(filePath);
+      }
+    }
+  }
+
+  private enforceCapacity(): void {
+    while (this.events.size > this.maxEvents) {
+      const oldestFilePath = this.events.keys().next().value;
+      if (oldestFilePath === undefined) break;
+      this.events.delete(oldestFilePath);
+    }
   }
 
   /**

--- a/packages/http/src/services/webhook/Live.ts
+++ b/packages/http/src/services/webhook/Live.ts
@@ -418,6 +418,8 @@ export class Live {
 export class LiveManager {
   private lives: Live[] = [];
 
+  constructor(private readonly maxCompletedLives = 100) {}
+
   /**
    * 获取所有 Live 实例（用于向后兼容）
    */
@@ -438,6 +440,28 @@ export class LiveManager {
    */
   addLive(live: Live): void {
     this.lives.push(live);
+    this.pruneCompletedLives();
+  }
+
+  private pruneCompletedLives(): void {
+    let completedCount = this.lives.filter(
+      (item) =>
+        item.parts.length > 0 &&
+        item.parts.every((part) => part.isFullyHandled() || part.isError()),
+    ).length;
+
+    if (completedCount <= this.maxCompletedLives) return;
+
+    this.lives = this.lives.filter((item) => {
+      const completed =
+        item.parts.length > 0 &&
+        item.parts.every((part) => part.isFullyHandled() || part.isError());
+      if (completed && completedCount > this.maxCompletedLives) {
+        completedCount--;
+        return false;
+      }
+      return true;
+    });
   }
 
   findBy(opts: { partId?: string; filePath?: string }): { live: Live; part: Part } | null {

--- a/packages/http/src/services/webhook/webhook.ts
+++ b/packages/http/src/services/webhook/webhook.ts
@@ -75,6 +75,8 @@ type SortParamItem = {
 };
 
 const SAME_MEDIA_UPLOAD_ORDER: Array<"handled" | "raw"> = ["handled", "raw"];
+const PROCESSED_FILE_TTL = 24 * 60 * 60 * 1000;
+const MAX_PROCESSED_FILES = 10_000;
 
 export class WebhookHandler {
   liveManager: LiveManager = new LiveManager();
@@ -83,7 +85,7 @@ export class WebhookHandler {
   danmuPreset: DanmuPreset;
   appConfig: AppConfig;
   configManager: ConfigManager;
-  private processedFiles: Set<string> = new Set();
+  private processedFiles: Map<string, number> = new Map();
   private fileRefManager: FileRefManager = new FileRefManager();
   eventBufferManager: EventBufferManager = new EventBufferManager();
 
@@ -558,8 +560,12 @@ export class WebhookHandler {
   ) {
     if (!(await fs.pathExists(filePath))) return;
 
+    const now = Date.now();
+    this.pruneProcessedFiles(now);
+
     // 检查文件是否已经处理过
-    if (this.processedFiles.has(filePath)) {
+    const processedAt = this.processedFiles.get(filePath);
+    if (processedAt !== undefined && now - processedAt < PROCESSED_FILE_TTL) {
       log.info(`文件已处理过，跳过同步: ${filePath}`);
       return;
     }
@@ -575,7 +581,7 @@ export class WebhookHandler {
     if (!livePart) return;
 
     // 将文件添加到已处理集合中
-    this.processedFiles.add(filePath);
+    this.processedFiles.set(filePath, now);
 
     // 提取基本信息
     let platform: Platform = "blrec";
@@ -616,6 +622,21 @@ export class WebhookHandler {
       });
     } catch (error) {
       log.error(`同步${fileType}文件失败: ${filePath}`, error);
+    }
+  }
+
+  private pruneProcessedFiles(now: number): void {
+    const expireBefore = now - PROCESSED_FILE_TTL;
+    for (const [filePath, processedAt] of this.processedFiles) {
+      if (processedAt <= expireBefore) {
+        this.processedFiles.delete(filePath);
+      }
+    }
+
+    while (this.processedFiles.size >= MAX_PROCESSED_FILES) {
+      const oldestFilePath = this.processedFiles.keys().next().value;
+      if (oldestFilePath === undefined) break;
+      this.processedFiles.delete(oldestFilePath);
     }
   }
 

--- a/packages/http/test/EventBufferManager.test.ts
+++ b/packages/http/test/EventBufferManager.test.ts
@@ -112,6 +112,27 @@ describe("EventBufferManager", () => {
 
       expect(manager.getBufferStatus()).toBe(2);
     });
+
+    it("should remove expired unpaired events when a new event arrives", () => {
+      vi.useFakeTimers();
+      const manager = new EventBufferManager(1000);
+      manager.addEvent(createMockEvent("FileOpening", "/path/to/old.mp4"));
+
+      vi.advanceTimersByTime(1001);
+      manager.addEvent(createMockEvent("FileOpening", "/path/to/new.mp4"));
+
+      expect(manager.getBufferStatus()).toBe(1);
+      vi.useRealTimers();
+    });
+
+    it("should cap the number of unpaired events", () => {
+      const manager = new EventBufferManager(60_000, 2);
+      manager.addEvent(createMockEvent("FileOpening", "/path/to/1.mp4"));
+      manager.addEvent(createMockEvent("FileOpening", "/path/to/2.mp4"));
+      manager.addEvent(createMockEvent("FileOpening", "/path/to/3.mp4"));
+
+      expect(manager.getBufferStatus()).toBe(2);
+    });
   });
 
   describe("clear", () => {

--- a/packages/http/test/Live.test.ts
+++ b/packages/http/test/Live.test.ts
@@ -1315,6 +1315,38 @@ describe("LiveManager", () => {
       expect(liveManager.getCount()).toBe(2);
       expect(liveManager.getAllLives()).toEqual([live1, live2]);
     });
+
+    it("应该限制已结束直播数量并保留活跃直播", () => {
+      const manager = new LiveManager(2);
+      const createLive = (eventId: string, status: "handled" | "recording") => {
+        const live = new Live({
+          eventId,
+          platform: "blrec",
+          roomId: eventId,
+          title: eventId,
+          username: "测试主播",
+          startTime: 1640995200000,
+        });
+        live.addPart({
+          filePath: `/path/to/${eventId}.mp4`,
+          recordStatus: status,
+          title: eventId,
+        });
+        return live;
+      };
+
+      const active = createLive("active", "recording");
+      manager.addLive(createLive("completed-1", "handled"));
+      manager.addLive(active);
+      manager.addLive(createLive("completed-2", "handled"));
+      manager.addLive(createLive("completed-3", "handled"));
+
+      expect(manager.getAllLives()).toEqual([
+        active,
+        expect.objectContaining({ eventId: "completed-2" }),
+        expect.objectContaining({ eventId: "completed-3" }),
+      ]);
+    });
   });
 
   describe("liveData getter/setter", () => {


### PR DESCRIPTION
## 修改内容

- 客户端断开时移除录制器弹幕 SSE 监听器
- 限制已完成 Webhook 直播记录的保留数量，同时保留活跃及处理中记录
- 为已处理文件的去重状态增加过期时间和数量上限
- 为未配对的 Webhook 事件缓冲增加过期时间和数量上限
- 增加事件缓冲及直播记录保留策略的回归测试

## 根本原因

多个进程级监听器和集合缺少断开清理、过期机制或数量限制，因此内存占用会随着 SSE 重连、已完成直播、同步文件以及未配对 Webhook 事件逐渐增长。

## 验证结果

- `pnpm --filter @biliLive-tools/http typecheck`
- `pnpm --filter @biliLive-tools/http test`（7 个测试文件，252 项测试通过）
- `git diff --check`

Closes #507