### PR TITLE
显示上传文件大小

### DIFF
--- a/packages/app/src/renderer/src/pages/Queue/components/item.vue
+++ b/packages/app/src/renderer/src/pages/Queue/components/item.vue
@@ -194,6 +194,9 @@
           )
         }}
       </span>
+      <span v-if="item.type === TaskType.biliUpload && item.extra?.fileSize !== undefined">
+        文件大小：{{ formatFileSize(item.extra.fileSize) }}
+      </span>
       <span>{{ item.custsomProgressMsg }}</span>
     </div>
   </div>
@@ -237,6 +240,21 @@ const props = withDefaults(defineProps<Props>(), {
 
 const item = computed(() => props.item);
 const isWeb = computed(() => window.isWeb);
+
+const formatFileSize = (size: number) => {
+  if (!Number.isFinite(size) || size < 0) return "--";
+  if (size < 1024) return `${size} B`;
+
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = size / 1024;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+
+  return `${value.toFixed(value < 10 ? 1 : 0)} ${units[unitIndex]}`;
+};
 
 const confirm = useConfirm();
 const store = useQueueStore();

--- a/packages/shared/src/task/task.ts
+++ b/packages/shared/src/task/task.ts
@@ -374,6 +374,14 @@ export class BiliPartVideoTask extends AbstractTask {
 
   async exec() {
     if (this.status !== "pending") return;
+
+    try {
+      const fileSize = await fs.stat(this.command.filePath).then((stat) => stat.size);
+      this.extra = { ...this.extra, fileSize };
+    } catch (error) {
+      log.warn(`task ${this.taskId} failed to read upload file size: ${error}`);
+    }
+
     this.status = "running";
     this.startTime = Date.now();
     this.emitter.emit("task-start", { taskId: this.taskId });


### PR DESCRIPTION
## 变更
B 站上传子任务在现有灰色详情行展示本地文件大小，位于速度字段前。

## 原因
任务列表仅展示上传速度，无法直接判断上传文件的总体积。

## 影响
仅读取本地上传文件的元数据，不访问 B 站，也不改变上传流程或预计还需逻辑。

## 验证
已通过 git diff --check。类型检查未完成：pnpm 因依赖目录与运行时不匹配触发重装，重装在 60 秒限制内未完成。