### PR TITLE
修复录制时间轴异常时的分段与上传保护

### DIFF
--- a/packages/liveManager/src/downloader/FFmpegDownloader.ts
+++ b/packages/liveManager/src/downloader/FFmpegDownloader.ts
@@ -12,6 +12,7 @@ export class FFmpegDownloader extends EventEmitter implements IDownloader {
   private command: ReturnType<typeof createFFMPEGBuilder>;
   private streamManager: StreamManager;
   private timeoutChecker: ReturnType<typeof utils.createTimeoutChecker>;
+  private segmentWatchdog: ReturnType<typeof setTimeout> | undefined;
   readonly hasSegment: boolean;
   readonly getSavePath: (data: { startTime: number; title?: string }) => string;
   readonly segment: Segment;
@@ -76,7 +77,7 @@ export class FFmpegDownloader extends EventEmitter implements IDownloader {
       },
     );
     this.timeoutChecker = utils.createTimeoutChecker(
-      () => this.onEnd("ffmpeg timeout"),
+      () => this.endRecording("ffmpeg timeout"),
       3 * 10e3,
       false,
     );
@@ -90,6 +91,7 @@ export class FFmpegDownloader extends EventEmitter implements IDownloader {
 
     this.command = this.createCommand();
     this.streamManager.on("videoFileCreated", ({ filename, cover, rawFilename, title }) => {
+      this.resetSegmentWatchdog();
       this.emit("videoFileCreated", { filename, cover, rawFilename, title });
     });
     this.streamManager.on("videoFileCompleted", (data) => {
@@ -137,15 +139,15 @@ export class FFmpegDownloader extends EventEmitter implements IDownloader {
       .inputOptions(inputOptions)
       .outputOptions(outputOptions)
       .output(this.streamManager.videoFilePath)
-      .on("error", this.onEnd)
-      .on("end", () => this.onEnd("finished"))
+      .on("error", (...args) => this.endRecording(...args))
+      .on("end", () => this.endRecording("finished"))
       .on("stderr", async (stderrLine) => {
         assert(typeof stderrLine === "string");
         this.emit("DebugLog", { type: "ffmpeg", text: stderrLine });
 
         const [isInvalid, reason] = isInvalidStream(stderrLine);
         if (isInvalid) {
-          this.onEnd(reason);
+          this.endRecording(reason);
         }
 
         await this.streamManager.handleVideoStarted(stderrLine);
@@ -156,6 +158,33 @@ export class FFmpegDownloader extends EventEmitter implements IDownloader {
       })
       .on("stderr", this.timeoutChecker?.update);
     return command;
+  }
+
+  private endRecording(...args: unknown[]) {
+    this.clearSegmentWatchdog();
+    this.onEnd(...args);
+  }
+
+  private resetSegmentWatchdog() {
+    this.clearSegmentWatchdog();
+    if (typeof this.segment !== "number" || this.segment <= 0) return;
+
+    const segmentDurationMs = this.segment * 60 * 1000;
+    const gracePeriodMs = Math.max(60 * 1000, segmentDurationMs * 0.1);
+    this.segmentWatchdog = setTimeout(() => {
+      this.segmentWatchdog = undefined;
+      this.emit("DebugLog", {
+        type: "error",
+        text: `Segment wall-clock timeout after ${segmentDurationMs + gracePeriodMs}ms`,
+      });
+      this.endRecording("segment wall-clock timeout");
+    }, segmentDurationMs + gracePeriodMs);
+  }
+
+  private clearSegmentWatchdog() {
+    if (!this.segmentWatchdog) return;
+    clearTimeout(this.segmentWatchdog);
+    this.segmentWatchdog = undefined;
   }
   buildOutputOptions() {
     const options: string[] = [];
@@ -215,6 +244,7 @@ export class FFmpegDownloader extends EventEmitter implements IDownloader {
 
   public async stop() {
     this.timeoutChecker.stop();
+    this.clearSegmentWatchdog();
     try {
       // ts文件使用write("q")需要十来秒进行处理，直接中断，其他格式使用sigint会导致缺少数据
       if (this.streamManager.videoFilePath.endsWith(".ts")) {

--- a/packages/liveManager/test/downloader/FFMPEGRecorder.test.ts
+++ b/packages/liveManager/test/downloader/FFMPEGRecorder.test.ts
@@ -22,15 +22,23 @@ describe("FFmpegDownloader", () => {
   let mockTimeoutChecker: any;
   let mockOnEnd: any;
   let mockOnUpdateLiveInfo: any;
+  let streamManagerListeners: Record<string, Array<(...args: any[]) => void>>;
+  let ffmpegListeners: Record<string, Array<(...args: any[]) => void>>;
 
   beforeEach(() => {
+    streamManagerListeners = {};
+    ffmpegListeners = {};
     // Mock FFMPEG builder
     mockFFMPEGBuilder = {
       input: vi.fn().mockReturnThis(),
       inputOptions: vi.fn().mockReturnThis(),
       outputOptions: vi.fn().mockReturnThis(),
       output: vi.fn().mockReturnThis(),
-      on: vi.fn().mockReturnThis(),
+      on: vi.fn(function (event: string, listener: (...args: any[]) => void) {
+        ffmpegListeners[event] ??= [];
+        ffmpegListeners[event].push(listener);
+        return this;
+      }),
       run: vi.fn(),
       kill: vi.fn(),
       _getArguments: vi.fn().mockReturnValue([]),
@@ -44,7 +52,11 @@ describe("FFmpegDownloader", () => {
     // Mock StreamManager
     mockStreamManager = {
       videoFilePath: "/test/path/video.mp4",
-      on: vi.fn(),
+      on: vi.fn((event: string, listener: (...args: any[]) => void) => {
+        streamManagerListeners[event] ??= [];
+        streamManagerListeners[event].push(listener);
+        return mockStreamManager;
+      }),
       handleVideoStarted: vi.fn(),
       handleVideoCompleted: vi.fn(),
       getExtraDataController: vi.fn(),
@@ -70,7 +82,93 @@ describe("FFmpegDownloader", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
+  });
+
+  describe("segment wall-clock watchdog", () => {
+    const createSegmentedRecorder = (segment = 30) =>
+      new FFmpegDownloader(
+        {
+          url: "https://example.com/stream.flv",
+          getSavePath: vi.fn().mockReturnValue("/test/path/video"),
+          segment,
+          outputOptions: [],
+          formatName: "flv",
+        },
+        mockOnEnd,
+        mockOnUpdateLiveInfo,
+      );
+
+    const emitVideoFileCreated = () => {
+      streamManagerListeners.videoFileCreated[0]({ filename: "/test/path/video.ts" });
+    };
+
+    it("ends the recording once when a segment exceeds its wall-clock deadline", () => {
+      vi.useFakeTimers();
+      createSegmentedRecorder(30);
+      emitVideoFileCreated();
+
+      vi.advanceTimersByTime(32 * 60 * 1000 + 59_999);
+      expect(mockOnEnd).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(mockOnEnd).toHaveBeenCalledTimes(1);
+      expect(mockOnEnd).toHaveBeenCalledWith("segment wall-clock timeout");
+
+      vi.advanceTimersByTime(60 * 60 * 1000);
+      expect(mockOnEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it("resets the deadline when the next segment is created", () => {
+      vi.useFakeTimers();
+      createSegmentedRecorder(10);
+      emitVideoFileCreated();
+
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      emitVideoFileCreated();
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      expect(mockOnEnd).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(60 * 1000);
+      expect(mockOnEnd).toHaveBeenCalledWith("segment wall-clock timeout");
+    });
+
+    it("clears the deadline when recording stops normally", async () => {
+      vi.useFakeTimers();
+      const recorder = createSegmentedRecorder(10);
+      emitVideoFileCreated();
+
+      await recorder.stop();
+      vi.advanceTimersByTime(60 * 60 * 1000);
+
+      expect(mockOnEnd).not.toHaveBeenCalled();
+    });
+
+    it("clears the deadline when FFmpeg ends", () => {
+      vi.useFakeTimers();
+      createSegmentedRecorder(10);
+      emitVideoFileCreated();
+
+      ffmpegListeners.end[0]();
+      vi.advanceTimersByTime(60 * 60 * 1000);
+
+      expect(mockOnEnd).toHaveBeenCalledTimes(1);
+      expect(mockOnEnd).toHaveBeenCalledWith("finished");
+    });
+
+    it("is independent from continuing FFmpeg stderr activity", () => {
+      vi.useFakeTimers();
+      createSegmentedRecorder(10);
+      emitVideoFileCreated();
+
+      vi.advanceTimersByTime(5 * 60 * 1000);
+      ffmpegListeners.stderr[1]("frame=100 time=00:01:00.00");
+      vi.advanceTimersByTime(6 * 60 * 1000);
+
+      expect(mockTimeoutChecker.update).toHaveBeenCalled();
+      expect(mockOnEnd).toHaveBeenCalledWith("segment wall-clock timeout");
+    });
   });
 
   describe("formatName and videoFormat parameter combinations", () => {

--- a/packages/shared/src/recorder/durationGuard.ts
+++ b/packages/shared/src/recorder/durationGuard.ts
@@ -1,0 +1,64 @@
+export interface RecordingDurationAnomaly {
+  wallDuration: number;
+  mediaDuration: number;
+  durationRatio: number;
+}
+
+export interface RecordingDurationCheckOptions {
+  recordStartTime: number;
+  recordEndTime: number;
+  mediaDuration: number;
+  minWallDuration?: number;
+  minDurationRatio?: number;
+}
+
+/**
+ * Detects a media timeline that advanced significantly slower than wall-clock time.
+ * Durations are expressed in seconds, timestamps in milliseconds.
+ */
+export function checkRecordingDuration({
+  recordStartTime,
+  recordEndTime,
+  mediaDuration,
+  minWallDuration = 60,
+  minDurationRatio = 0.8,
+}: RecordingDurationCheckOptions): RecordingDurationAnomaly | null {
+  const wallDuration = (recordEndTime - recordStartTime) / 1000;
+  if (
+    !Number.isFinite(wallDuration) ||
+    !Number.isFinite(mediaDuration) ||
+    wallDuration <= minWallDuration ||
+    mediaDuration <= 0
+  ) {
+    return null;
+  }
+
+  const durationRatio = mediaDuration / wallDuration;
+  if (durationRatio >= minDurationRatio) return null;
+
+  return {
+    wallDuration,
+    mediaDuration,
+    durationRatio,
+  };
+}
+
+export function getRecordingCompletionAction(anomaly: RecordingDurationAnomaly | null): {
+  shouldRunPostProcess: boolean;
+  externalEvent: "file_completed" | "file_error";
+  webhookEvent: "FileClosed" | "FileError";
+} {
+  if (anomaly) {
+    return {
+      shouldRunPostProcess: false,
+      externalEvent: "file_error",
+      webhookEvent: "FileError",
+    };
+  }
+
+  return {
+    shouldRunPostProcess: true,
+    externalEvent: "file_completed",
+    webhookEvent: "FileClosed",
+  };
+}

--- a/packages/shared/src/recorder/index.ts
+++ b/packages/shared/src/recorder/index.ts
@@ -29,6 +29,11 @@ import {
   sendExternalEventRequest,
 } from "../utils/index.js";
 import RecorderConfig from "./config.js";
+import {
+  checkRecordingDuration,
+  getRecordingCompletionAction,
+  type RecordingDurationAnomaly,
+} from "./durationGuard.js";
 import { sendBySystem, send } from "../notify.js";
 import { danmaReport, parseDanmu } from "../danmu/index.js";
 
@@ -506,6 +511,8 @@ export async function createRecorderManager(appConfig: AppConfig) {
     const channelId = recorder?.channelId;
     const liveId = recorder?.liveInfo?.liveId;
     const config = appConfig.getAll();
+    let durationAnomaly: RecordingDurationAnomaly | null = null;
+    let completionAction = getRecordingCompletionAction(durationAnomaly);
 
     try {
       const xmlFile = replaceExtName(filename, ".xml");
@@ -517,6 +524,28 @@ export async function createRecorderManager(appConfig: AppConfig) {
       } catch (error) {
         logger.error("读取视频元信息失败", { filename, error });
       }
+
+      const history = recordHistory.getRecord({
+        file: filename,
+        live_id: liveId,
+      });
+      if (history) {
+        durationAnomaly = checkRecordingDuration({
+          recordStartTime: history.record_start_time,
+          recordEndTime: endTime.getTime(),
+          mediaDuration: Number(duration),
+        });
+      }
+      if (durationAnomaly) {
+        logger.error("录制时长异常，保留文件并跳过自动处理", {
+          recorderId: recorder.id,
+          roomId: recorder.channelId,
+          platform: recorder.providerId,
+          filename,
+          ...durationAnomaly,
+        });
+      }
+      completionAction = getRecordingCompletionAction(durationAnomaly);
 
       // 提取文件名（不含后缀）
       const videoFilename = path.basename(filename, path.extname(filename));
@@ -567,7 +596,7 @@ export async function createRecorderManager(appConfig: AppConfig) {
         );
       }
 
-      if (data?.convert2Mp4) {
+      if (completionAction.shouldRunPostProcess && data?.convert2Mp4) {
         try {
           await convert2Mp4(filename);
           await fs.unlink(filename);
@@ -579,16 +608,22 @@ export async function createRecorderManager(appConfig: AppConfig) {
     } catch (error) {
       logger.error("Update live error", { recorder, filename, error });
     } finally {
-      await sendRecorderExternalEvent("file_completed", {
+      await sendRecorderExternalEvent(completionAction.externalEvent, {
         filePath: filename,
         roomId: String(recorder.channelId),
         platform: recorder.providerId,
+        ...(durationAnomaly
+          ? {
+              reason: "recording duration mismatch",
+              ...durationAnomaly,
+            }
+          : {}),
       });
 
       if (data?.sendToWebhook) {
         const webhookUrl = `http://127.0.0.1:${config.port}/webhook/custom`;
         const payload = {
-          event: "FileClosed",
+          event: completionAction.webhookEvent,
           filePath: filename,
           roomId: channelId,
           time: endTime.toISOString(),

--- a/packages/shared/test/recorder/durationGuard.test.ts
+++ b/packages/shared/test/recorder/durationGuard.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  checkRecordingDuration,
+  getRecordingCompletionAction,
+} from "../../src/recorder/durationGuard.js";
+
+describe("checkRecordingDuration", () => {
+  it("accepts a normal 30-minute recording", () => {
+    expect(
+      checkRecordingDuration({
+        recordStartTime: 0,
+        recordEndTime: 30 * 60 * 1000,
+        mediaDuration: 29 * 60 + 58,
+      }),
+    ).toBeNull();
+  });
+
+  it("detects the incident where 1:41:25 of recording became 23:40 of media", () => {
+    const result = checkRecordingDuration({
+      recordStartTime: 0,
+      recordEndTime: 6085 * 1000,
+      mediaDuration: 1420,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.wallDuration).toBe(6085);
+    expect(result?.mediaDuration).toBe(1420);
+    expect(result?.durationRatio).toBeCloseTo(1420 / 6085);
+  });
+
+  it("does not judge recordings at or below the minimum wall duration", () => {
+    expect(
+      checkRecordingDuration({
+        recordStartTime: 0,
+        recordEndTime: 60 * 1000,
+        mediaDuration: 10,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not treat missing ffprobe duration as a proven timeline anomaly", () => {
+    expect(
+      checkRecordingDuration({
+        recordStartTime: 0,
+        recordEndTime: 10 * 60 * 1000,
+        mediaDuration: 0,
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts the configured ratio boundary", () => {
+    expect(
+      checkRecordingDuration({
+        recordStartTime: 0,
+        recordEndTime: 100 * 1000,
+        mediaDuration: 80,
+      }),
+    ).toBeNull();
+  });
+
+  it("routes anomalous files to error events without automatic post-processing", () => {
+    const anomaly = checkRecordingDuration({
+      recordStartTime: 0,
+      recordEndTime: 6085 * 1000,
+      mediaDuration: 1420,
+    });
+
+    expect(getRecordingCompletionAction(anomaly)).toEqual({
+      shouldRunPostProcess: false,
+      externalEvent: "file_error",
+      webhookEvent: "FileError",
+    });
+  });
+
+  it("keeps the normal completion route for healthy files", () => {
+    expect(getRecordingCompletionAction(null)).toEqual({
+      shouldRunPostProcess: true,
+      externalEvent: "file_completed",
+      webhookEvent: "FileClosed",
+    });
+  });
+});


### PR DESCRIPTION
Closes #524

## 变更

- 为 FFmpeg 时间分段增加独立的墙上时间 watchdog，在 segmentDuration + max(60 秒, 10%) 内没有新分段时结束当前录制并进入现有重试流程。
- 在新分段、正常停止、FFmpeg 结束和异常退出时重置或清理 timer；watchdog 不依赖 stderr 活动或媒体 time。
- 文件完成后比较真实录制时长与 ffprobe 媒体时长；真实时长超过 60 秒且媒体/真实比例低于 0.8 时标记异常。
- 异常文件保留，跳过自动转封装和源文件删除，发送 file_error / FileError，避免进入正常上传完成流程。
- 补充 watchdog、正常清理、持续 stderr、事故时长样本及异常路由测试。

## 根因

FFmpeg segment_time 依赖媒体时间轴。抖音 FLV 输入存在错误但非缺失的 PTS/DTS 时，genpts/igndts 无法重建正确时间轴；原有 timeout checker 又只判断 FFmpeg 是否持续输出，因此会把仍在写入但媒体时间推进异常的进程视为正常。文件完成后也缺少真实时长与媒体时长的交叉校验。

## 影响

时间戳异常不再无限拖延分段；即使异常文件已经生成，也不会被静默当作正常文件转封装、上传或删除。正常录制及 ffprobe 失败场景保持原有完成路径。

## 验证

- FFmpegDownloader 针对性测试：31 passed
- durationGuard 针对性测试：7 passed
- liveManager TypeScript 类型检查通过
- shared TypeScript 类型检查通过
- Prettier 与 git diff --check 通过
- 最新 master 全仓 Vitest：747 passed，6 skipped，1 failed；唯一失败为 packages/TikTokRecorder/test/stream.test.ts 的既有 HEVC 错误消息断言，与本 PR 修改文件无关。
