### PR TITLE
feat(bili-upload): add user-selected route pools and scheduling strategies

### DIFF
--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -287,7 +287,9 @@
 
   // ===== B 站上传配置 =====
   biliUpload: {
-    line: "auto", // 上传线路: auto|kodo|bda2|upos|cos
+    line: "auto", // 兼容旧版本的上传线路；保存线路池时自动回填为 lines[0]
+    lines: ["auto"], // 上传线路池；auto 只能单独使用
+    lineStrategy: "fixed", // 调度策略: fixed|round-robin|random
     concurrency: 3, // 并发上传数
     limitRate: 0, // 上传限速 (KB/s, 0=不限制)
     retryTimes: 10, // 重试次数

--- a/packages/app/src/renderer/src/pages/setting/BiliSetting.vue
+++ b/packages/app/src/renderer/src/pages/setting/BiliSetting.vue
@@ -4,12 +4,32 @@
       <n-form-item>
         <template #label>
           <Tip
-            text="线路"
-            tip="上传线路，自动会使用B站接口返回的第一个线路，如果上传失败请手动选择线路，切换后请上传测试线路能否实际使用。<br/>qn线路可能对海外机器有特效<br/>访问查询：<a href='https://member.bilibili.com/preupload?r=ping' target='_blank'>https://member.bilibili.com/preupload?r=ping</a>"
+            text="上传线路池"
+            tip="每个视频上传会话只会从所选线路池中选择一次线路，同一视频的全部分片不会中途换线。自动线路只能单独使用。"
             placement="bottom"
           ></Tip>
         </template>
-        <n-select v-model:value="config.biliUpload.line" :options="lineOptions" filterable tag />
+        <n-select
+          v-model:value="selectedLines"
+          :options="lineOptions"
+          filterable
+          multiple
+          :max-tag-count="'responsive'"
+          placeholder="请至少选择一条上传线路"
+        />
+      </n-form-item>
+      <n-form-item>
+        <template #label>
+          <Tip
+            text="线路调度"
+            tip="单线路固定使用；轮询会按账号在每个新视频上传会话间依次切换；随机只会从所选线路池中选择。"
+          ></Tip>
+        </template>
+        <n-select
+          v-model:value="lineStrategy"
+          :options="lineStrategyOptions"
+          :disabled="selectedLines.length === 1"
+        />
       </n-form-item>
       <n-form-item>
         <template #label>
@@ -111,7 +131,14 @@
 
 <script setup lang="ts">
 import { useBreakpoints } from "@renderer/hooks";
-import type { AppConfig } from "@biliLive-tools/types";
+import {
+  BILI_UPLOAD_ACTIVE_LINE_SELECTORS,
+  BILI_UPLOAD_LEGACY_LINE_SELECTORS,
+  normalizeBiliUploadRouteConfig,
+} from "@biliLive-tools/shared/biliUploadRoute.js";
+import { resolveBiliUploadLineSelection } from "./biliUploadLines";
+
+import type { AppConfig, BiliUploadLineStrategy } from "@biliLive-tools/types";
 
 const config = defineModel<AppConfig>("data", {
   default: () => {},
@@ -121,36 +148,52 @@ const labelWidth = computed(() => {
   return isMobile.value ? "90px" : "150px";
 });
 
+const selectedLines = computed<string[]>({
+  get() {
+    return normalizeBiliUploadRouteConfig(config.value.biliUpload).lines;
+  },
+  set(value) {
+    const lines = resolveBiliUploadLineSelection(value, selectedLines.value);
+    config.value.biliUpload.lines = lines;
+    config.value.biliUpload.line = lines[0];
+    if (lines.length === 1) {
+      config.value.biliUpload.lineStrategy = "fixed";
+    } else if (
+      config.value.biliUpload.lineStrategy !== "round-robin" &&
+      config.value.biliUpload.lineStrategy !== "random"
+    ) {
+      config.value.biliUpload.lineStrategy = "round-robin";
+    }
+  },
+});
+
+const lineStrategy = computed<BiliUploadLineStrategy>({
+  get() {
+    return normalizeBiliUploadRouteConfig(config.value.biliUpload).lineStrategy;
+  },
+  set(value) {
+    config.value.biliUpload.lineStrategy = selectedLines.value.length === 1 ? "fixed" : value;
+  },
+});
+
+const lineStrategyOptions = computed(() => {
+  if (selectedLines.value.length === 1) {
+    return [{ label: "固定", value: "fixed" }];
+  }
+  return [
+    { label: "轮询", value: "round-robin" },
+    { label: "随机", value: "random" },
+  ];
+});
+
 const lineOptions = [
   { label: "自动", value: "auto" },
-  { label: "cs-bda2", value: "cs-bda2" },
-  { label: "cs-bldsa", value: "cs-bldsa" },
-  { label: "cs-tx", value: "cs-tx" },
-  { label: "cs-qn", value: "cs-qn" },
-  { label: "cs-cnbldsa", value: "cs-cnbldsa" },
-  { label: "cs-akbd", value: "cs-akbd" },
-  { label: "cs-estx", value: "cs-estx" },
-  { label: "cs-cnbd", value: "cs-cnbd" },
-  { label: "cs-cntx", value: "cs-cntx" },
-  { label: "cs-andsa", value: "cs-andsa" },
-  { label: "cs-anbd", value: "cs-anbd" },
-  { label: "cs-antx", value: "cs-antx" },
-  { label: "cs-atdsa", value: "cs-atdsa" },
-  { label: "cs-atbd", value: "cs-atbd" },
-  { label: "cs-attx", value: "cs-attx" },
+  ...BILI_UPLOAD_ACTIVE_LINE_SELECTORS.map((line) => ({ label: line, value: line })),
   {
     type: "group",
     key: "outdated",
     label: "可能已失效线路（仅供测试）",
-    children: [
-      { label: "cs-txa", value: "cs-txa" },
-      { label: "cs-alia", value: "cs-alia" },
-      { label: "jd-bldsa", value: "jd-bldsa" },
-      { label: "jd-bd", value: "jd-bd" },
-      { label: "jd-tx", value: "jd-tx" },
-      { label: "jd-txa", value: "jd-txa" },
-      { label: "jd-alia", value: "jd-alia" },
-    ],
+    children: BILI_UPLOAD_LEGACY_LINE_SELECTORS.map((line) => ({ label: line, value: line })),
   },
 ];
 </script>

--- a/packages/app/src/renderer/src/pages/setting/biliUploadLines.ts
+++ b/packages/app/src/renderer/src/pages/setting/biliUploadLines.ts
@@ -1,0 +1,25 @@
+import {
+  isBiliUploadLineSelector,
+  normalizeBiliUploadLines,
+  type BiliUploadLineSelector,
+} from "@biliLive-tools/shared/biliUploadRoute.js";
+
+export function resolveBiliUploadLineSelection(
+  nextLines: readonly string[],
+  currentLines: readonly string[],
+): BiliUploadLineSelector[] {
+  const validNextLines = [...new Set(nextLines.filter(isBiliUploadLineSelector))];
+  const validCurrentLines = normalizeBiliUploadLines(currentLines);
+
+  if (validNextLines.length === 0) {
+    return validCurrentLines;
+  }
+
+  const addedLine = validNextLines.find((line) => !validCurrentLines.includes(line));
+  if (addedLine === "auto") {
+    return ["auto"];
+  }
+
+  const fixedLines = validNextLines.filter((line) => line !== "auto");
+  return fixedLines.length > 0 ? fixedLines : ["auto"];
+}

--- a/packages/app/test/biliUploadLines.test.ts
+++ b/packages/app/test/biliUploadLines.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveBiliUploadLineSelection } from "../src/renderer/src/pages/setting/biliUploadLines";
+
+describe("BiliSetting upload line selection", () => {
+  it("选择 auto 时替换已有固定线路", () => {
+    expect(resolveBiliUploadLineSelection(["cs-qn", "cs-alia", "auto"], ["cs-qn", "cs-alia"]))
+      .toEqual(["auto"]);
+  });
+
+  it("从 auto 选择固定线路时移除 auto", () => {
+    expect(resolveBiliUploadLineSelection(["auto", "cs-qn"], ["auto"])).toEqual(["cs-qn"]);
+  });
+
+  it("拒绝清空最后一条线路和未知 selector", () => {
+    expect(resolveBiliUploadLineSelection([], ["cs-qn"])).toEqual(["cs-qn"]);
+    expect(resolveBiliUploadLineSelection(["unknown"], ["cs-qn"])).toEqual(["cs-qn"]);
+  });
+});

--- a/packages/shared/src/biliUploadRoute.ts
+++ b/packages/shared/src/biliUploadRoute.ts
@@ -1,0 +1,155 @@
+import type { AppConfig, BiliUploadLineStrategy } from "@biliLive-tools/types";
+
+export const BILI_UPLOAD_ACTIVE_LINE_SELECTORS = [
+  "cs-bda2",
+  "cs-bldsa",
+  "cs-tx",
+  "cs-qn",
+  "cs-cnbldsa",
+  "cs-akbd",
+  "cs-estx",
+  "cs-cnbd",
+  "cs-cntx",
+  "cs-andsa",
+  "cs-anbd",
+  "cs-antx",
+  "cs-atdsa",
+  "cs-atbd",
+  "cs-attx",
+] as const;
+
+export const BILI_UPLOAD_LEGACY_LINE_SELECTORS = [
+  "cs-txa",
+  "cs-alia",
+  "jd-bldsa",
+  "jd-bd",
+  "jd-tx",
+  "jd-txa",
+  "jd-alia",
+] as const;
+
+export const BILI_UPLOAD_LINE_SELECTORS = [
+  "auto",
+  ...BILI_UPLOAD_ACTIVE_LINE_SELECTORS,
+  ...BILI_UPLOAD_LEGACY_LINE_SELECTORS,
+] as const;
+
+export type BiliUploadLineSelector = (typeof BILI_UPLOAD_LINE_SELECTORS)[number];
+
+type UploadRouteConfig = Pick<AppConfig["biliUpload"], "line" | "lines" | "lineStrategy">;
+type NormalizedUploadRouteConfig<T> = Omit<T, keyof UploadRouteConfig> & {
+  line: BiliUploadLineSelector;
+  lines: BiliUploadLineSelector[];
+  lineStrategy: BiliUploadLineStrategy;
+};
+
+const allowedSelectors = new Set<string>(BILI_UPLOAD_LINE_SELECTORS);
+
+export function isBiliUploadLineSelector(value: unknown): value is BiliUploadLineSelector {
+  return typeof value === "string" && allowedSelectors.has(value);
+}
+
+export function normalizeBiliUploadLines(
+  lines: readonly unknown[] | undefined,
+  legacyLine: unknown = "auto",
+): BiliUploadLineSelector[] {
+  const fallback = isBiliUploadLineSelector(legacyLine) ? legacyLine : "auto";
+  const source = Array.isArray(lines) && lines.length > 0 ? lines : [fallback];
+  const uniqueLines = [...new Set(source.filter(isBiliUploadLineSelector))];
+
+  if (uniqueLines.length === 0) {
+    return [fallback];
+  }
+
+  // Malformed persisted values are resolved deterministically: the first valid
+  // selector wins when it is auto; otherwise auto is removed from the fixed pool.
+  if (uniqueLines[0] === "auto") {
+    return ["auto"];
+  }
+
+  const fixedLines = uniqueLines.filter((line) => line !== "auto");
+  return fixedLines.length > 0 ? fixedLines : ["auto"];
+}
+
+export function normalizeBiliUploadRouteConfig<T extends Partial<UploadRouteConfig>>(
+  config: T,
+): NormalizedUploadRouteConfig<T> {
+  const lines = normalizeBiliUploadLines(config.lines, config.line);
+  const lineStrategy: BiliUploadLineStrategy =
+    lines.length === 1
+      ? "fixed"
+      : config.lineStrategy === "random" || config.lineStrategy === "round-robin"
+        ? config.lineStrategy
+        : "round-robin";
+
+  return {
+    ...config,
+    line: lines[0],
+    lines,
+    lineStrategy,
+  };
+}
+
+export type RouteSelectionContext = {
+  accountId: string;
+  taskId: string;
+  lines: readonly string[];
+  strategy: BiliUploadLineStrategy;
+};
+
+export type RouteSelection = {
+  selector: BiliUploadLineSelector;
+  zone: string;
+  line: string;
+};
+
+export function parseBiliUploadRouteSelector(selector: string): RouteSelection {
+  const normalizedSelector = isBiliUploadLineSelector(selector) ? selector : "auto";
+  if (normalizedSelector === "auto") {
+    return { selector: normalizedSelector, zone: "", line: "auto" };
+  }
+
+  const separatorIndex = normalizedSelector.indexOf("-");
+  return {
+    selector: normalizedSelector,
+    zone: normalizedSelector.slice(0, separatorIndex),
+    line: normalizedSelector.slice(separatorIndex + 1),
+  };
+}
+
+export function getSanitizedUploadEndpointHost(url: string): string {
+  try {
+    return new URL(url).hostname || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+export class BiliUploadRouteScheduler {
+  private readonly cursors = new Map<string, number>();
+
+  constructor(private readonly rng: () => number = Math.random) {}
+
+  select(context: RouteSelectionContext): RouteSelection {
+    const lines = normalizeBiliUploadLines(context.lines);
+    const strategy = lines.length === 1 ? "fixed" : context.strategy;
+    let index = 0;
+
+    if (strategy === "round-robin") {
+      const cursor = this.cursors.get(context.accountId) ?? 0;
+      index = cursor % lines.length;
+      this.cursors.set(context.accountId, cursor + 1);
+    } else if (strategy === "random") {
+      const randomIndex = Math.floor(this.rng() * lines.length);
+      index = Math.min(Math.max(randomIndex, 0), lines.length - 1);
+    }
+
+    return parseBiliUploadRouteSelector(lines[index]);
+  }
+
+  reset() {
+    this.cursors.clear();
+  }
+}
+
+export const biliUploadRouteScheduler = new BiliUploadRouteScheduler();

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -6,6 +6,7 @@ import { defaultsDeep, get, set, cloneDeep } from "lodash-es";
 import { TypedEmitter } from "tiny-typed-emitter";
 import { APP_DEFAULT_CONFIG } from "./enum.js";
 import log from "./utils/log.js";
+import { normalizeBiliUploadRouteConfig } from "./biliUploadRoute.js";
 
 import type { AppConfig as AppConfigType, DeepPartial } from "@biliLive-tools/types";
 
@@ -106,6 +107,8 @@ export class AppConfig extends Config {
 
     const initData = defaultsDeep(data, APP_DEFAULT_CONFIG);
     super.init(filepath, initData);
+    this.data.biliUpload = normalizeBiliUploadRouteConfig(this.data.biliUpload);
+    this.save();
   }
   get<K extends keyof AppConfigType>(key: K): AppConfigType[K];
   get<TPath extends string>(key: TPath): ReturnType<typeof get>;
@@ -119,10 +122,23 @@ export class AppConfig extends Config {
   set<K extends keyof AppConfigType>(key: K, value: AppConfigType[K]): void;
   set(key: string, value: any): void;
   set(key: keyof AppConfigType | string, value: any) {
-    return super.set(key, value);
+    this.read();
+    const oldData = cloneDeep(this.data);
+    set(this.data, key, value);
+    if (String(key) === "biliUpload.line") {
+      this.data.biliUpload.lines = [value];
+    }
+    if (String(key) === "biliUpload" || String(key).startsWith("biliUpload.")) {
+      this.data.biliUpload = normalizeBiliUploadRouteConfig(this.data.biliUpload);
+    }
+    this.save();
+    this.emit("update", this.data, oldData);
   }
   setAll(newConfig: AppConfigType) {
-    return super.setAll(newConfig);
+    return super.setAll({
+      ...newConfig,
+      biliUpload: normalizeBiliUploadRouteConfig(newConfig.biliUpload),
+    });
   }
   getAll() {
     const data = this.read() as AppConfigType;

--- a/packages/shared/src/task/bili.ts
+++ b/packages/shared/src/task/bili.ts
@@ -20,6 +20,12 @@ import { sleep, encrypt, decrypt, getTempPath, trashItem, uuid } from "../utils/
 import { sendNotify } from "../notify.js";
 import { getBinPath, pasrseMetadata } from "./video.js";
 import { formatTitle, formatPartTitle, formatDesc, buildRoomLink } from "../utils/webhook.js";
+import {
+  biliUploadRouteScheduler,
+  getSanitizedUploadEndpointHost,
+  normalizeBiliUploadRouteConfig,
+  type RouteSelection,
+} from "../biliUploadRoute.js";
 
 import type { BiliupConfig, BiliUser, AppConfig as AppConfigType } from "@biliLive-tools/types";
 import type { MediaOptions, DescV2 } from "@renmu/bili-api/dist/types/index.js";
@@ -423,22 +429,79 @@ export async function editMediaApi(
 /**
  * 格式化上传稿件参数，并非上传接口
  */
-function formatMediaOptions(options: AppConfigType["biliUpload"]) {
-  let line = options.line ?? "auto";
-  const splitedLine = line.split("-");
-  let zone = "";
-
-  if (splitedLine.length === 2) {
-    [zone, line] = splitedLine;
-  }
-
+function formatMediaOptions(options: AppConfigType["biliUpload"], route: RouteSelection) {
   return {
     ...options,
-    line: line,
-    zone: zone,
+    line: route.line,
+    zone: route.zone,
     limitRate: Math.floor((options.limitRate || 0) / (options.concurrency || 1)),
     bcutPreUpload: true,
   };
+}
+
+type RouteLogContext = {
+  selector: string;
+  strategy: string;
+  taskId: string;
+  accountId: string;
+};
+
+class RoutedWebVideoUploader extends WebVideoUploader {
+  constructor(
+    part: ConstructorParameters<typeof WebVideoUploader>[0],
+    auth: ConstructorParameters<typeof WebVideoUploader>[1],
+    options: ConstructorParameters<typeof WebVideoUploader>[2],
+    private readonly routeLogContext: RouteLogContext,
+  ) {
+    super(part, auth, options);
+  }
+
+  bindTask(taskId: string) {
+    this.routeLogContext.taskId = taskId;
+    const { selector, strategy, accountId } = this.routeLogContext;
+    log.info(
+      `[bili-upload] route selected selector=${selector} strategy=${strategy} taskId=${taskId} accountId=${accountId}`,
+    );
+  }
+
+  override async preupload() {
+    const result = await super.preupload();
+    const endpointHost = getSanitizedUploadEndpointHost(result.url);
+    const { selector, taskId, accountId } = this.routeLogContext;
+    log.info(
+      `[bili-upload] preupload resolved selector=${selector} endpointHost=${endpointHost} taskId=${taskId} accountId=${accountId}`,
+    );
+    return result;
+  }
+}
+
+function createRoutedUploader(
+  part: ConstructorParameters<typeof WebVideoUploader>[0],
+  auth: ConstructorParameters<typeof WebVideoUploader>[1],
+  uploadOptions: AppConfigType["biliUpload"],
+  context: { uid: number; taskId: string },
+) {
+  const routeConfig = normalizeBiliUploadRouteConfig(uploadOptions);
+  const accountId = String(context.uid);
+  const route = biliUploadRouteScheduler.select({
+    accountId,
+    taskId: context.taskId,
+    lines: routeConfig.lines,
+    strategy: routeConfig.lineStrategy,
+  });
+  const routeLogContext = {
+    selector: route.selector,
+    strategy: routeConfig.lineStrategy,
+    taskId: context.taskId,
+    accountId,
+  };
+
+  return new RoutedWebVideoUploader(
+    part,
+    auth,
+    formatMediaOptions(uploadOptions, route),
+    routeLogContext,
+  );
 }
 
 /**
@@ -807,7 +870,10 @@ async function addMedia(
   const config = appConfig.getAll();
   const uploadOptions = config.biliUpload;
   for (const part of videos) {
-    const uploader = new WebVideoUploader(part, client.auth, formatMediaOptions(uploadOptions));
+    const uploader = createRoutedUploader(part, client.auth, uploadOptions, {
+      uid,
+      taskId: pTask.taskId,
+    });
 
     const task = new BiliPartVideoTask(
       uploader,
@@ -819,6 +885,7 @@ async function addMedia(
       },
       {},
     );
+    uploader.bindTask(task.taskId);
 
     taskQueue.addTask(task, false);
     pTask.addTask(task);
@@ -910,7 +977,10 @@ export async function editMedia(
   const config = appConfig.getAll();
   const uploadOptions = config.biliUpload;
   for (const part of videos) {
-    const uploader = new WebVideoUploader(part, client.auth, formatMediaOptions(uploadOptions));
+    const uploader = createRoutedUploader(part, client.auth, uploadOptions, {
+      uid,
+      taskId: pTask.taskId,
+    });
 
     const task = new BiliPartVideoTask(
       uploader,
@@ -922,6 +992,7 @@ export async function editMedia(
       },
       {},
     );
+    uploader.bindTask(task.taskId);
 
     taskQueue.addTask(task, false);
     pTask.addTask(task);
@@ -949,7 +1020,10 @@ export function addExtraVideoTask(pTaskId: string, filePath: string, partName: s
     title: partName,
   };
   const client = createClient(pTask.uid);
-  const uploader = new WebVideoUploader(part, client.auth, formatMediaOptions(uploadOptions));
+  const uploader = createRoutedUploader(part, client.auth, uploadOptions, {
+    uid: pTask.uid,
+    taskId: pTask.taskId,
+  });
 
   const task = new BiliPartVideoTask(
     uploader,
@@ -961,6 +1035,7 @@ export function addExtraVideoTask(pTaskId: string, filePath: string, partName: s
     },
     {},
   );
+  uploader.bindTask(task.taskId);
 
   taskQueue.addTask(task, false);
   pTask.addTask(task);

--- a/packages/shared/test/biliUploadRoute.test.ts
+++ b/packages/shared/test/biliUploadRoute.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BiliUploadRouteScheduler,
+  getSanitizedUploadEndpointHost,
+  normalizeBiliUploadLines,
+  normalizeBiliUploadRouteConfig,
+  parseBiliUploadRouteSelector,
+} from "../src/biliUploadRoute.js";
+
+describe("normalizeBiliUploadRouteConfig", () => {
+  it("将旧单线路配置迁移为固定线路池", () => {
+    expect(normalizeBiliUploadRouteConfig({ line: "cs-qn" })).toMatchObject({
+      line: "cs-qn",
+      lines: ["cs-qn"],
+      lineStrategy: "fixed",
+    });
+    expect(normalizeBiliUploadRouteConfig({ line: "auto" })).toMatchObject({
+      line: "auto",
+      lines: ["auto"],
+      lineStrategy: "fixed",
+    });
+  });
+
+  it("去重、过滤未知线路并回填兼容 line", () => {
+    expect(
+      normalizeBiliUploadRouteConfig({
+        line: "auto",
+        lines: ["cs-qn", "unknown", "cs-qn", "cs-alia"],
+        lineStrategy: "random",
+      }),
+    ).toMatchObject({
+      line: "cs-qn",
+      lines: ["cs-qn", "cs-alia"],
+      lineStrategy: "random",
+    });
+  });
+
+  it("保证 auto 与固定线路互斥，并为空数组提供旧字段回退", () => {
+    expect(normalizeBiliUploadLines(["auto", "cs-qn"], "cs-qn")).toEqual(["auto"]);
+    expect(normalizeBiliUploadLines(["cs-qn", "auto"], "auto")).toEqual(["cs-qn"]);
+    expect(normalizeBiliUploadLines([], "cs-alia")).toEqual(["cs-alia"]);
+    expect(normalizeBiliUploadLines(["unknown"], "cs-qn")).toEqual(["cs-qn"]);
+  });
+
+  it("endpoint 日志值只保留主机名", () => {
+    expect(
+      getSanitizedUploadEndpointHost(
+        "https://user:password@upos.example.com/path/video?auth=sensitive&signature=secret",
+      ),
+    ).toBe("upos.example.com");
+    expect(getSanitizedUploadEndpointHost("not-a-url?auth=sensitive")).toBe("unknown");
+  });
+
+  it("多线路的无效或固定策略回退为轮询", () => {
+    expect(
+      normalizeBiliUploadRouteConfig({
+        line: "cs-qn",
+        lines: ["cs-qn", "cs-alia"],
+        lineStrategy: "fixed",
+      }).lineStrategy,
+    ).toBe("round-robin");
+  });
+});
+
+describe("BiliUploadRouteScheduler", () => {
+  it("fixed 始终选择第一条并拆分 zone/line", () => {
+    const scheduler = new BiliUploadRouteScheduler();
+    const context = {
+      accountId: "1",
+      taskId: "task-1",
+      lines: ["cs-qn", "cs-alia"],
+      strategy: "fixed" as const,
+    };
+
+    expect(scheduler.select(context)).toEqual({ selector: "cs-qn", zone: "cs", line: "qn" });
+    expect(scheduler.select(context)).toEqual({ selector: "cs-qn", zone: "cs", line: "qn" });
+    expect(parseBiliUploadRouteSelector("auto")).toEqual({
+      selector: "auto",
+      zone: "",
+      line: "auto",
+    });
+  });
+
+  it("round-robin 按账号独立循环", () => {
+    const scheduler = new BiliUploadRouteScheduler();
+    const select = (accountId: string) =>
+      scheduler.select({
+        accountId,
+        taskId: `task-${accountId}`,
+        lines: ["cs-qn", "cs-alia"],
+        strategy: "round-robin",
+      }).selector;
+
+    expect([select("1"), select("1"), select("1")]).toEqual(["cs-qn", "cs-alia", "cs-qn"]);
+    expect([select("2"), select("2")]).toEqual(["cs-qn", "cs-alia"]);
+  });
+
+  it("random 只从用户线路池选择且可注入 RNG", () => {
+    const first = new BiliUploadRouteScheduler(() => 0);
+    const last = new BiliUploadRouteScheduler(() => 0.999999);
+    const context = {
+      accountId: "1",
+      taskId: "task-1",
+      lines: ["cs-qn", "cs-alia"],
+      strategy: "random" as const,
+    };
+
+    expect(first.select(context).selector).toBe("cs-qn");
+    expect(last.select(context).selector).toBe("cs-alia");
+  });
+});

--- a/packages/shared/test/config.test.ts
+++ b/packages/shared/test/config.test.ts
@@ -89,7 +89,7 @@ describe("Config", () => {
         nested: {
           value: 1,
         },
-      }
+      },
     );
     expect(onUpdate).toHaveBeenNthCalledWith(
       2,
@@ -105,7 +105,7 @@ describe("Config", () => {
         nested: {
           value: 2,
         },
-      }
+      },
     );
     expect(JSON.parse(fs.readFileSync(configPath, "utf-8"))).toEqual({
       nested: {
@@ -197,5 +197,58 @@ describe("AppConfig", () => {
 
     const persisted = JSON.parse(fs.readFileSync(configPath, "utf-8"));
     expect(persisted.tool.download.override).toBe(true);
+  });
+
+  it("将旧 biliUpload.line 配置迁移为单线路固定模式", () => {
+    fs.writeFileSync(configPath, JSON.stringify({ biliUpload: { line: "cs-qn" } }));
+    const config = new AppConfig();
+
+    config.init(configPath);
+
+    expect(config.get("biliUpload")).toMatchObject({
+      line: "cs-qn",
+      lines: ["cs-qn"],
+      lineStrategy: "fixed",
+    });
+    expect(JSON.parse(fs.readFileSync(configPath, "utf-8")).biliUpload).toMatchObject({
+      line: "cs-qn",
+      lines: ["cs-qn"],
+      lineStrategy: "fixed",
+    });
+  });
+
+  it("保存线路池时规范化 selector 并回填旧 line 字段", () => {
+    const config = new AppConfig();
+    config.init(configPath);
+    const current = config.getAll();
+
+    config.setAll({
+      ...current,
+      biliUpload: {
+        ...current.biliUpload,
+        line: "auto",
+        lines: ["cs-qn", "unknown", "cs-qn", "cs-alia"],
+        lineStrategy: "random",
+      },
+    });
+
+    expect(config.get("biliUpload")).toMatchObject({
+      line: "cs-qn",
+      lines: ["cs-qn", "cs-alia"],
+      lineStrategy: "random",
+    });
+  });
+
+  it("兼容通过旧 biliUpload.line 路径更新单线路", () => {
+    const config = new AppConfig();
+    config.init(configPath);
+
+    config.set("biliUpload.line", "cs-qn");
+
+    expect(config.get("biliUpload")).toMatchObject({
+      line: "cs-qn",
+      lines: ["cs-qn"],
+      lineStrategy: "fixed",
+    });
   });
 });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,6 +2,8 @@ export * from "./task.js";
 import type { Line as UploadLine } from "@renmu/bili-api";
 export * from "./preset.js";
 
+export type BiliUploadLineStrategy = "fixed" | "round-robin" | "random";
+
 // 弹幕配置
 // export type DanmuConfig = {
 //   resolution: [number, number];
@@ -818,6 +820,10 @@ export interface AppConfig {
   biliUpload: {
     /** 线路 */
     line: UploadLine;
+    /** 用户允许使用的上传线路池；缺省时兼容读取 line */
+    lines?: UploadLine[];
+    /** 上传会话的线路调度策略 */
+    lineStrategy?: BiliUploadLineStrategy;
     /** 上传重试次数 */
     retryTimes: number;
     /** 上传超时时间 */


### PR DESCRIPTION
由AI发布

## Summary

Implements PR 1 of #538: a user-controlled Bilibili upload route pool and per-session scheduling strategy, while preserving existing single-line configurations.

Refs: #538

## Changes

- Backward-compatible migration from `biliUpload.line` to `lines + lineStrategy`
- Multi-select upload route UI with `auto`/fixed-route mutual exclusion
- Fixed, round-robin, and random session-level scheduling
- Per-account in-memory round-robin cursors and injectable RNG for tests
- Route selection at all three `WebVideoUploader` creation points
- Sanitized logs for selector, strategy, task/account IDs, and resolved endpoint hostname
- Config migration, scheduler, UI interaction, and log-sanitization tests
- Configuration documentation

## Behavior

Selection happens once before each video-part upload session creates its uploader. All chunks in that session continue to use the endpoint and credentials returned by the same preupload request.

`auto` remains supported only as a standalone option. It cannot be mixed into a user-controlled fixed route pool. Single-route pools always resolve to the fixed strategy.

## Backward compatibility

- Existing `biliUpload.line` configurations migrate to a one-item fixed pool.
- Direct updates through the legacy `biliUpload.line` config path remain supported.
- The first selected route is written back to `line` for downgrade compatibility.
- Empty, duplicate, mixed-auto, and unknown selectors are normalized.

## Security

- Logs retain only the endpoint hostname.
- Cookies, upload auth, `upos_uri`, signed URLs, query signatures, complete request headers, and complete preupload responses are not logged.
- The UI only accepts maintained selector values and cannot inject arbitrary URLs.

## Tests

- 27 targeted tests passed.
- Types, shared, app main-process, and Vue type checks passed.
- The complete Vitest run reported 753 passed, 6 skipped, and 3 unrelated existing failures in PowerSaveController/TikTokRecorder tests.
- Standard pnpm build/lint commands are currently blocked by the local dependency state: Electron native rebuild requires Visual Studio, and the installed Vue ESLint config exposes an incompatible package subpath.

## Manual verification

1. Upgrade an existing single-line configuration.
2. Select two fixed routes and save.
3. Verify round-robin across separate video-part upload sessions.
4. Verify all chunks of one session stay on one endpoint.
5. Verify route logs contain only selector metadata and endpoint hostname.
6. Restart and confirm the pool persists.

## Out of scope

- Route health checks and endpoint deduplication (planned PR 2)
- Health-priority scheduling (planned PR 2)
- Session rebuild and automatic failover (planned PR 3)
- Mid-session chunk host switching